### PR TITLE
Re-enabled data portal RDS serverless auto-pause

### DIFF
--- a/terraform/stacks/umccr_data_portal/main.tf
+++ b/terraform/stacks/umccr_data_portal/main.tf
@@ -1132,7 +1132,9 @@ resource "aws_rds_cluster" "db" {
   db_subnet_group_name = "${aws_db_subnet_group.rds.name}"
 
   scaling_configuration {
-    auto_pause = false
+    auto_pause   = "${var.rds_auto_pause[terraform.workspace]}"
+    min_capacity = "${var.rds_min_capacity[terraform.workspace]}"
+    max_capacity = "${var.rds_max_capacity[terraform.workspace]}"
   }
 }
 

--- a/terraform/stacks/umccr_data_portal/variables.tf
+++ b/terraform/stacks/umccr_data_portal/variables.tf
@@ -75,8 +75,24 @@ variable "lims_csv_file_key" {
 
 variable "rds_auto_pause" {
     default = {
-        prod = true,
-        dev = false
+        prod = false,
+        dev  = true
     }
-    description = "Whether we always keep serverless rds alive"
+    description = "Whether to keep RDS serverless alive or pause if no load"
+}
+
+variable "rds_min_capacity" {
+    default = {
+        prod = 2,
+        dev  = 1
+    }
+    description = "The minimum capacity in Aurora Capacity Units (ACUs)"
+}
+
+variable "rds_max_capacity" {
+    default = {
+        prod = 16,
+        dev  = 1
+    }
+    description = "The maximum capacity in Aurora Capacity Units (ACUs)"
 }


### PR DESCRIPTION
* Added option to configure RDS serverless scaling config
* Made DEV scale down to lowest possible: 1 ACU
* Re-activated DEV serverless auto-pause to investigate issue again
* Meanwhile stay put PROD auto-pause off