### PR TITLE
Added networking stack for main vpc

### DIFF
--- a/terraform/stacks/networking/README.md
+++ b/terraform/stacks/networking/README.md
@@ -1,0 +1,106 @@
+# Networking
+
+- This stack prepare AWS VPC network topology required for app deployment.
+- This stack leverages [HashiCorp official AWS provider](https://registry.terraform.io/providers/hashicorp/aws/) VPC module available at [terraform-aws-modules / vpc](https://registry.terraform.io/modules/terraform-aws-modules/vpc/aws/) in module registry.
+- This [terraform-aws-modules / vpc](https://registry.terraform.io/modules/terraform-aws-modules/vpc/aws/) is comprehensive module for VPC purpose and, able to adapt many network topology needs as its grows.
+- It can also (re)create Gruntworks style Three Subnet Tiers for application deployment purpose i.e. [vpc-app](https://github.com/umccr/gruntworks-io-module-vpc/tree/master/modules/vpc-app) module.
+
+## Subnet Tiers
+
+At the moment, this VPC defines three "tiers" of subnets:
+
+- **Public** subnets: Resources in these subnets are directly addressable from the Internet. Only public-facing resources (typically just load balancers) should be put here.
+- **Private** (Private/App) subnets: Resources in these subnets are NOT directly addressable from the Internet but they can make outbound connections to the Internet through a NAT Gateway. You can connect to the resources in this subnet only from resources within the VPC, so you should put your app servers here and allow the load balancers in the Public Subnet to route traffic to them.
+- **Database** (Private/Persistence) subnets: Resources in these subnets are neither directly addressable from the Internet nor able to make outbound Internet connections. You can connect to the resources in this subnet only from within the VPC, so you should put your databases, cache servers, and other stateful resources here and allow your apps to talk to them.
+
+## Usage
+
+- Print output for VPC ID: `terraform output`
+
+#### Terraform
+
+- In your app terraform, you can use [data source: aws_vpc](https://www.terraform.io/docs/providers/aws/d/vpc.html) to query this VPC by its ID.
+
+- You may further filter subnet by its tier. Example for how to filter _Private_ subnets using tag: `Tier = "private"`
+
+```hcl-terraform
+variable "main_vpc_id" {
+  default = "vpc-01234567890" # output of main vpc ID
+}
+
+data "aws_vpc" "main_vpc" {
+  id = var.main_vpc_id
+}
+
+data "aws_subnet_ids" "private_subnets" {
+  vpc_id = data.aws_vpc.main_vpc.id
+
+  tags = {
+    Tier = "private"
+  }
+}
+```
+
+#### CDK
+
+- In your stack, say `common.py`:
+
+```python
+from aws_cdk import (
+    core,
+    aws_ec2 as ec2,
+)
+
+class CommonStack(core.Stack):
+    def __init__(self, scope: core.Construct, id: str, props, **kwargs) -> None:
+        super().__init__(scope, id, **kwargs)
+
+        vpc = ec2.Vpc.from_lookup(self, "VPC", vpc_id=props['vpc_id'])
+        self._vpc = vpc
+
+    @property
+    def vpc(self):
+        return self._vpc
+```
+
+- And somewhere in `app.py`:
+
+```python
+from aws_cdk import core
+from stacks.batch import BatchStack
+from stacks.common import CommonStack
+
+app = core.App()
+
+common_props = {
+    'vpc_id': 'vpc-01234567890'  # output of main vpc ID
+}
+
+batch_app_props = {}
+
+common = CommonStack(
+    app,
+    common_props['namespace'],
+    common_props,
+)
+
+batch_app_props['vpc'] = common.vpc
+BatchStack(
+    app,
+    batch_app_props['namespace'],
+    batch_app_props,
+)
+
+app.synth()
+```
+
+## Workspaces
+
+This stack uses workspaces! It is typically applied against the AWS `prod` and `dev` accounts and uses Terraform workspaces to distinguish between those accounts. 
+
+```
+aws sso login --profile=dev
+export AWS_PROFILE=dev
+terraform workspace select dev
+terraform ...
+```

--- a/terraform/stacks/networking/main.tf
+++ b/terraform/stacks/networking/main.tf
@@ -1,0 +1,76 @@
+terraform {
+  required_version = ">= 0.12"
+
+  backend "s3" {
+    bucket = "umccr-terraform-states"
+    key    = "networking/terraform.tfstate"
+    region = "ap-southeast-2"
+  }
+}
+
+provider "aws" {
+  version = "~> 2.64"
+  region  = "ap-southeast-2"
+}
+
+resource "aws_eip" "main_vpc_nat_gateway" {
+  count = 1
+  vpc = true
+
+  tags = {
+    Name        = "main-vpc-nat-gateway-eip"
+    Environment = terraform.workspace
+    Stack       = var.stack_name
+    Creator     = "terraform"
+  }
+}
+
+module "main_vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "2.38.0"
+
+  name = "main-vpc"
+  cidr = "10.2.0.0/16"
+
+  azs              = ["ap-southeast-2a", "ap-southeast-2b", "ap-southeast-2c"]
+  public_subnets   = ["10.2.0.0/23",  "10.2.2.0/23",  "10.2.4.0/23"]
+  private_subnets  = ["10.2.20.0/23", "10.2.22.0/23", "10.2.24.0/23"]
+  database_subnets = ["10.2.40.0/23", "10.2.42.0/23", "10.2.44.0/23"]
+
+  // Single NAT Gateway Scenario
+  enable_nat_gateway     = true
+  single_nat_gateway     = true
+  one_nat_gateway_per_az = false
+
+  reuse_nat_ips       = true
+  external_nat_ip_ids = aws_eip.main_vpc_nat_gateway.*.id
+
+  create_database_subnet_group           = true
+  create_database_subnet_route_table     = true
+  create_database_nat_gateway_route      = false  # true to give internet access (egress only)
+  create_database_internet_gateway_route = false  # true for ingress from internet (NOT RECOMMENDED FOR PRODUCTION)
+
+  enable_dns_hostnames = false
+  enable_dns_support   = true
+
+  public_subnet_tags = {
+    SubnetType = "public"
+    Tier       = var.public_tag
+  }
+
+  private_subnet_tags = {
+    SubnetType = "private_app"
+    Tier       = var.private_tag
+  }
+
+  database_subnet_tags = {
+    SubnetType = "private_persistence"
+    Tier       = var.database_tag
+  }
+
+  tags = {
+    Environment = terraform.workspace
+    Stack       = var.stack_name
+    Creator     = "terraform"
+  }
+}

--- a/terraform/stacks/networking/outputs.tf
+++ b/terraform/stacks/networking/outputs.tf
@@ -1,0 +1,37 @@
+output "vpc_id" {
+  description = "The ID of the VPC"
+  value       = module.main_vpc.vpc_id
+}
+
+output "vpc_name" {
+  description = "Name of the VPC"
+  value       = module.main_vpc.name
+}
+
+output "private_subnets" {
+  description = "List of IDs of private subnets"
+  value       = module.main_vpc.private_subnets
+}
+
+output "public_subnets" {
+  description = "List of IDs of public subnets"
+  value       = module.main_vpc.public_subnets
+}
+
+output "database_subnets" {
+  description = "List of IDs of database subnets"
+  value       = module.main_vpc.database_subnets
+}
+
+output "nat_public_ips" {
+  description = "List of public Elastic IPs created for AWS NAT Gateway"
+  value       = aws_eip.main_vpc_nat_gateway.*.public_ip
+}
+
+output "database_subnet_arns" {
+  value = module.main_vpc.database_subnet_arns
+}
+
+output "database_subnet_group" {
+  value = module.main_vpc.database_subnet_group
+}

--- a/terraform/stacks/networking/variables.tf
+++ b/terraform/stacks/networking/variables.tf
@@ -1,0 +1,15 @@
+variable "stack_name" {
+  default = "networking"
+}
+
+variable "public_tag" {
+  default = "public"
+}
+
+variable "private_tag" {
+  default = "private"
+}
+
+variable "database_tag" {
+  default = "database"
+}


### PR DESCRIPTION
* This stack creates common main vpc for use in app deployment
* VPC CIDR block is /16 i.e. ~65534 hosts
* Setup 3 tiers with 3 AZs, total 9 subnets in /23 i.e. ~510 hosts per subnet
* Started use terraform >= 0.12
* Leverage VPC module from HasiCorp official public module registry
* README for how to utilise this main vpc