### PR TITLE
Allowed DNS hostname in networking stack main vpc

### DIFF
--- a/terraform/stacks/networking/debug.py
+++ b/terraform/stacks/networking/debug.py
@@ -1,0 +1,93 @@
+import os
+
+from aws_cdk import (
+    core,
+    aws_ec2 as ec2,
+)
+
+# See https://docs.aws.amazon.com/cdk/latest/guide/environments.html
+env_profile = core.Environment(
+    account=os.environ.get('CDK_DEPLOY_ACCOUNT', os.environ['CDK_DEFAULT_ACCOUNT']),
+    region=os.environ.get('CDK_DEPLOY_REGION', os.environ['CDK_DEFAULT_REGION'])
+)
+
+
+class DebugStack(core.Stack):
+    def __init__(self, scope: core.Construct, id: str, props, **kwargs) -> None:
+        super().__init__(scope, id, **kwargs)
+
+        # Using tags filter on networking stack to get main-vpc in given env context
+        vpc_name = "main-vpc"
+        vpc_tags = {
+            'Stack': 'networking',
+        }
+        vpc = ec2.Vpc.from_lookup(self, "VPC", vpc_name=vpc_name, tags=vpc_tags)
+
+        print(">>> ec2.SubnetSelection(subnets=vpc.private_subnets)")
+        vpc_subnet_selection: ec2.SubnetSelection = ec2.SubnetSelection(subnets=vpc.private_subnets)
+        for subnet in vpc_subnet_selection.subnets:
+            print(subnet.subnet_id)
+
+        print(">>> subnet_group_name='database'")
+        vpc_db_subnets: ec2.SelectedSubnets = vpc.select_subnets(subnet_group_name="database")
+        for subnet in vpc_db_subnets.subnets:
+            print(subnet.subnet_id)
+
+        print(">>> ec2.SubnetType.PRIVATE")
+        vpc_private_subnets: ec2.SelectedSubnets = vpc.select_subnets(subnet_type=ec2.SubnetType.PRIVATE)
+        for subnet in vpc_private_subnets.subnets:
+            print(subnet.subnet_id)
+
+        print(">>> vpc.private_subnets")
+        for subnet in vpc.private_subnets:
+            print(subnet.subnet_id)
+
+        print(">>> vpc.public_subnets")
+        for subnet in vpc.public_subnets:
+            print(subnet.subnet_id)
+
+        print(">>> vpc.isolated_subnets")
+        for subnet in vpc.isolated_subnets:
+            print(subnet.subnet_id)
+
+
+class DebugApp(core.App):
+    def __init__(self):
+        super().__init__()
+        DebugStack(self, "debug-stack", props={}, env=env_profile)
+
+
+if __name__ == '__main__':
+    DebugApp().synth()
+
+
+# Usage:
+# aws sso login --profile=dev
+# Latest yawsso >= 0.3.0 support multiple named profiles sync, btw!!
+# pip install -U yawsso
+# yawsso -p dev prod
+# cdk synth --app="python3 debug.py" --profile=dev
+# cdk synth --app="python3 debug.py" --profile=prod
+# cdk context -j | jq
+
+# Footnote:
+# Wondering those wired subnets id print upon first time synth like the following?
+"""
+>>> ec2.SubnetSelection(subnets=vpc.private_subnets)
+p-12345
+p-67890
+>>> subnet_group_name='database'
+>>> ec2.SubnetType.PRIVATE
+p-12345
+p-67890
+>>> vpc.private_subnets
+p-12345
+p-67890
+>>> vpc.public_subnets
+s-12345
+s-67890
+>>> vpc.isolated_subnets
+"""
+# See https://github.com/aws/aws-cdk/blob/v1.44.0/packages/@aws-cdk/aws-ec2/lib/vpc.ts#L1922
+# If you missed that try `cdk context --clear` and synth again!
+# :)

--- a/terraform/stacks/networking/main.tf
+++ b/terraform/stacks/networking/main.tf
@@ -50,7 +50,7 @@ module "main_vpc" {
   create_database_nat_gateway_route      = false  # true to give internet access (egress only)
   create_database_internet_gateway_route = false  # true for ingress from internet (NOT RECOMMENDED FOR PRODUCTION)
 
-  enable_dns_hostnames = false
+  enable_dns_hostnames = true
   enable_dns_support   = true
 
   public_subnet_tags = {

--- a/terraform/stacks/networking/main.tf
+++ b/terraform/stacks/networking/main.tf
@@ -53,19 +53,26 @@ module "main_vpc" {
   enable_dns_hostnames = true
   enable_dns_support   = true
 
+  # See README Subnet Tagging section for the following tags combination
   public_subnet_tags = {
-    SubnetType = "public"
-    Tier       = var.public_tag
+    SubnetType            = var.umccr_subnet_tier.PUBLIC
+    Tier                  = var.umccr_subnet_tier.PUBLIC
+    "aws-cdk:subnet-name" = var.umccr_subnet_tier.PUBLIC
+    "aws-cdk:subnet-type" = var.aws_cdk_subnet_type.PUBLIC
   }
 
   private_subnet_tags = {
-    SubnetType = "private_app"
-    Tier       = var.private_tag
+    SubnetType            = var.umccr_subnet_tier.PRIVATE
+    Tier                  = var.umccr_subnet_tier.PRIVATE
+    "aws-cdk:subnet-name" = var.umccr_subnet_tier.PRIVATE
+    "aws-cdk:subnet-type" = var.aws_cdk_subnet_type.PRIVATE
   }
 
   database_subnet_tags = {
-    SubnetType = "private_persistence"
-    Tier       = var.database_tag
+    SubnetType            = var.umccr_subnet_tier.DATABASE
+    Tier                  = var.umccr_subnet_tier.DATABASE
+    "aws-cdk:subnet-name" = var.umccr_subnet_tier.DATABASE
+    "aws-cdk:subnet-type" = var.aws_cdk_subnet_type.ISOLATED
   }
 
   tags = {

--- a/terraform/stacks/networking/variables.tf
+++ b/terraform/stacks/networking/variables.tf
@@ -2,14 +2,22 @@ variable "stack_name" {
   default = "networking"
 }
 
-variable "public_tag" {
-  default = "public"
+variable "umccr_subnet_tier" {
+  # Follow UMCCR specific tag convention
+  # https://github.com/umccr/wiki/tree/master/computing/cloud/amazon#general-conventions
+  default = {
+    PRIVATE  = "private"
+    PUBLIC   = "public"
+    DATABASE = "database"
+  }
 }
 
-variable "private_tag" {
-  default = "private"
-}
-
-variable "database_tag" {
-  default = "database"
+variable "aws_cdk_subnet_type" {
+  # Follow CDK convention
+  # https://github.com/aws/aws-cdk/blob/v1.44.0/packages/@aws-cdk/aws-ec2/lib/vpc.ts#L139
+  default = {
+    PRIVATE  = "Private"
+    PUBLIC   = "Public"
+    ISOLATED = "Isolated"
+  }
 }


### PR DESCRIPTION
* Usually DNS hostname is desirable
* Updated README to get this main vpc by name and tags filter
  Reduce attack surface by making lesser known VPC ID
  exposure in downstream terraform and CDK code