### PR TITLE
Samplesheet by index len

### DIFF
--- a/scripts/showcase/samplesheet-prep-test.py
+++ b/scripts/showcase/samplesheet-prep-test.py
@@ -73,10 +73,10 @@ def get_args():
     parser.add_argument("--output-path", "--outputPath", "-o", type=str, required=True, dest="output_path")
 
     sample_params_args = parser.add_argument_group("Parameters for filtering out samples."
-                                                   "If --sample-type, --index-legnth or --index2length"
-                                                   "are used. A file named SampleSheet.csv will be output."
+                                                   "If --sample-type, --index-length or --index2-length "
+                                                   "are used. A file named SampleSheet.csv will be output. "
                                                    "If the --all parameter is used, then each file named will be "
-                                                   "distinguished with the following notation"
+                                                   "distinguished with the following notation "
                                                    "SampleSheet_<sample_type>.<index-length>.<index2-length>.csv")
     sample_params_args.add_argument("--sample-type", type=str, required=False, default='WGS',
                                     help="Type of samples we wish to keep")


### PR DESCRIPTION
This adjusts the samplesheet-split script with the following changes for bclconvert compatibility.

1. Samplesheets split by sample type AND also by index lengths.
2. Trailing Ns in indexes removed.
3. Additional parameters `--all`, `--sample-type`, `--index-length`, `--index2-length` added.

Use `--all` to keep previous logic, which creates a samplesheet for each combination of sample type and index length with the naming convention `SampleSheet_<sample_type>.<index_length>.<index2_length>.csv`.

Use `--sample-type` and `--index-length` and `--index2-length` to specifiy a samplesheet at the location `--output-path`.
The defaults of `--sample-type`, `--index-length` and `--index2-length` are 'WGS', '8' and '8' respectively.


