### PR TITLE
Rerouted from temp-dev to research dev, built-in AccessFrom to cluster to prevent ssh access from everywhere

### DIFF
--- a/parallel_cluster/README.md
+++ b/parallel_cluster/README.md
@@ -200,6 +200,13 @@ If however you can see the logs, and everything seems okay it may be worth doing
 2. Check that the `compute` node is not in drain mode, `scontrol show partition=compute`.
 3. If you have used `srun --pty bash` to login to the node, use `sinteractive` instead due to a known bug.
 
+### Cannot log into AWS SSO whilst in pcluster env
+This is caused by a decision from aws not to support v2 on pip.  
+When you run the pcluster installation command it installs aws v1 onto your conda env.  
+You'll need to open up a new shell (that is not in your pcluster conda env) to login via sso.  
+Many people arent happy about this. You can rant to them [here][aws_doesnt_support_pip_bug]
+
+
 [install_doc]: https://docs.aws.amazon.com/parallelcluster/latest/ug/install.html
 [blog_1]: https://aws.amazon.com/blogs/machine-learning/building-an-interactive-and-scalable-ml-research-environment-using-aws-parallelcluster/
 [aws_parallel_cluster]: https://aws.amazon.com/hpc/parallelcluster/
@@ -210,3 +217,4 @@ If however you can see the logs, and everything seems okay it may be worth doing
 [sbatch_guide]: https://slurm.schedmd.com/sbatch.html
 [sbcast_guide]: https://slurm.schedmd.com/sbcast.html
 [cromshell_repo]: https://github.com/broadinstitute/cromshell
+[aws_doesnt_support_pip_bug]: https://github.com/aws/aws-cli/issues/4947

--- a/parallel_cluster/README.md
+++ b/parallel_cluster/README.md
@@ -206,6 +206,9 @@ When you run the pcluster installation command it installs aws v1 onto your cond
 You'll need to open up a new shell (that is not in your pcluster conda env) to login via sso.  
 Many people arent happy about this. You can rant to them [here][aws_doesnt_support_pip_bug]
 
+### The vpc ID 'vpc-XXXX' does not exist
+This can be caused by trying to access a network configuration outside your permissions.
+Ensure you're setting `--cluster-template` correctly and pointing to the right config-file with `--config`
 
 [install_doc]: https://docs.aws.amazon.com/parallelcluster/latest/ug/install.html
 [blog_1]: https://aws.amazon.com/blogs/machine-learning/building-an-interactive-and-scalable-ml-research-environment-using-aws-parallelcluster/

--- a/parallel_cluster/ami/bcbio.yml
+++ b/parallel_cluster/ami/bcbio.yml
@@ -15,9 +15,9 @@ phases:
       - name: download_cromwell_files
         action: S3Download
         inputs:
-          - source: "s3://umccr-temp-dev/Alexis_parallel_cluster_test/bcbio/env/*"
+          - source: "s3://umccr-research-dev/parallel-cluster/bcbio/env/*"
             destination: "/opt/bcbio/env/"
-          - source: "s3://umccr-temp-dev/Alexis_parallel_cluster_test/bcbio/config/*"
+          - source: "s3://umccr-research-dev/parallel-cluster/bcbio/config/*"
             destination: "/opt/bcbio/config/"
       - name: bcbio
         action: ExecuteBash

--- a/parallel_cluster/ami/cleanup.yml
+++ b/parallel_cluster/ami/cleanup.yml
@@ -1,0 +1,14 @@
+name: cleanup
+description: Cleanup before image creation
+schemaVersion: 1.0
+
+phases:
+  - name: build
+    steps:
+      - name: ami-cleanup
+        action: ExecuteBash
+        inputs:
+          commands:
+            # Run a simple ami cleanup
+            - |
+              /usr/local/sbin/ami_cleanup.sh

--- a/parallel_cluster/ami/cromwell.yml
+++ b/parallel_cluster/ami/cromwell.yml
@@ -16,11 +16,11 @@ phases:
       - name: download_cromwell_files
         action: S3Download
         inputs:
-          - source: "s3://umccr-temp-dev/Alexis_parallel_cluster_test/cromwell/configs/*"
+          - source: "s3://umccr-research-dev/parallel-cluster/cromwell/configs/*"
             destination: "/opt/cromwell/configs/"
-          - source: "s3://umccr-temp-dev/Alexis_parallel_cluster_test/cromwell/env/*"
+          - source: "s3://umccr-research-dev/parallel-cluster/cromwell/env/*"
             destination: "/opt/cromwell/env/"
-          - source: "s3://umccr-temp-dev/Alexis_parallel_cluster_test/cromwell/scripts/*"
+          - source: "s3://umccr-research-dev/parallel-cluster/cromwell/scripts/*"
             destination: "/opt/cromwell/scripts/"
       - name: cromwell
         action: ExecuteBash

--- a/parallel_cluster/bin/start_cluster.sh
+++ b/parallel_cluster/bin/start_cluster.sh
@@ -6,6 +6,13 @@ echo_stderr(){
     echo "${@}" 1>&2
 }
 
+get_local_ip(){
+  # Returns the local ip address
+  local local_ip
+  local_ip=$(dig +short myip.opendns.com @resolver1.opendns.com)
+  echo "${local_ip}"
+}
+
 display_help() {
     # Display help message then exit
     echo_stderr "Usage: $0 NAME_OF_YOUR_CLUSTER "
@@ -27,6 +34,26 @@ check_pcluster_version() {
   # Used to ensure that pcluster is in our PATH
   pcluster version >/dev/null 2>&1
   return "$?"
+}
+
+append_ip_to_extra_parameters() {
+  local extra_parameters
+  extra_parameters="$(echo "$1" | {
+                     # Add AccessFrom attribute - output in raw format
+                     jq ".AccessFrom = \"$(get_local_ip)/0\"" \
+                       --compact-output
+                    } | {
+                      # Compact output is too compact
+                      # Add space in between colons
+                      sed 's/:/: /g'
+                    } | {
+                      # In between commas also helps readability
+                      sed 's/,/, /g'
+                    } | {
+                      # We need these quotes to be escaped
+                      sed 's/"/\\\"/g'
+                    })"
+  echo "${extra_parameters}"
 }
 
 if ! check_pcluster_version; then
@@ -103,9 +130,20 @@ else
 fi
 
 # Check extra parameters argument
-if [[ -n "${extra_parameters}" ]]; then
-  pcluster_args="${pcluster_args} --extra-parameters=\"${extra_parameters}\""
+if [[ -z "${extra_parameters}" ]]; then
+  # Initialise extra parameters json
+  extra_parameters="{}"
+elif ! echo "${extra_parameters}" | jq empty; then
+  # Existing jq failed
+  echo_stderr "Could not parse \"${extra_parameters}\" into jq. Exiting"
 fi
+
+# Add local IP to extra parameters as the only place we can access ssh from
+# We don't actually need SSH as we run through ssm
+extra_parameters="$(append_ip_to_extra_parameters "${extra_parameters}")"
+
+# Eval mitigation is done in the append_ip_to_extra_parameters command
+pcluster_args="${pcluster_args} --extra-parameters \"${extra_parameters}\""
 
 # Check no-rollback argument
 if [[ "${no_rollback}" == "true" ]]; then
@@ -117,40 +155,35 @@ fi
 # Add creator tag to pcluster args
 pcluster_args="${pcluster_args} --tags \"{\\\"Creator\\\": \\\"${USER}\\\"}\""
 
-# Ensure cluster-name is set
-if [[ "${cluster_name_arg}" ]]; then
-    # Log what's going to be run
-    echo_stderr "Running the following command:"
-    echo_stderr "pcluster create ${pcluster_args}"
-    # Initialise the cluster
-    if ! eval pcluster create "${pcluster_args}"; then
-      echo_stderr "Could not create the parallel cluster stack, exiting"
-      exit 1
-    else
-      echo_stderr "Stack creation succeeded - now retrieving name of IP"
-    fi
-
-    # Output the master IP to log
-    # We list both those in pending/initializing or running states.
-    # And we ensure that this is our instance by specifying the Creator tag
-    instance_id="$(aws ec2 describe-instances \
-                     --query "Reservations[*].Instances[*].[InstanceId]" \
-                     --filters "Name=instance-state-name,Values=pending,running" \
-                               "Name=tag:Name,Values=Master" \
-                               "Name=tag:Creator,Values=\"${USER}\"" \
-                     --output text)"
-
-    if [[ -z "${instance_id}" ]]; then
-      echo_stderr "Could not retrieve instance ID"
-    else
-      echo_stderr "Got instance_id ${instance_id}"
-      echo_stderr "Log into your cluster with \"ssm ${instance_id}\""
-    fi
-
-	  # FIXME: control error codes better, avoiding counterintuitive ones: i.e authed within a different account:
-	  # ERROR: The configuration parameter 'vpc_id' generated the following errors:
-	  # The vpc ID 'vpc-7d2b2e1a' does not exist
-	  # OR ERROR:  The following resource(s) failed to create: [MasterServerWaitCondition, ComputeFleet].
+# Log what's going to be run
+echo_stderr "Running the following command:"
+eval echo "pcluster create ${pcluster_args}" 1>&2
+# Initialise the cluster
+if ! eval pcluster create "${pcluster_args}"; then
+  echo_stderr "Could not create the parallel cluster stack, exiting"
+  exit 1
 else
-    display_help
+  echo_stderr "Stack creation succeeded - now retrieving name of IP"
 fi
+
+# Output the master IP to log
+# We list both those in pending/initializing or running states.
+# And we ensure that this is our instance by specifying the Creator tag
+instance_id="$(aws ec2 describe-instances \
+                 --query "Reservations[*].Instances[*].[InstanceId]" \
+                 --filters "Name=instance-state-name,Values=pending,running" \
+                           "Name=tag:Name,Values=Master" \
+                           "Name=tag:Creator,Values=\"${USER}\"" \
+                 --output text)"
+
+if [[ -z "${instance_id}" ]]; then
+  echo_stderr "Could not retrieve instance ID"
+else
+  echo_stderr "Got instance_id ${instance_id}"
+  echo_stderr "Log into your cluster with \"ssm ${instance_id}\""
+fi
+
+# FIXME: control error codes better, avoiding counterintuitive ones: i.e authed within a different account:
+# ERROR: The configuration parameter 'vpc_id' generated the following errors:
+# The vpc ID 'vpc-7d2b2e1a' does not exist
+# OR ERROR:  The following resource(s) failed to create: [MasterServerWaitCondition, ComputeFleet].

--- a/parallel_cluster/bin/start_cluster.sh
+++ b/parallel_cluster/bin/start_cluster.sh
@@ -182,8 +182,3 @@ else
   echo_stderr "Got instance_id ${instance_id}"
   echo_stderr "Log into your cluster with \"ssm ${instance_id}\""
 fi
-
-# FIXME: control error codes better, avoiding counterintuitive ones: i.e authed within a different account:
-# ERROR: The configuration parameter 'vpc_id' generated the following errors:
-# The vpc ID 'vpc-7d2b2e1a' does not exist
-# OR ERROR:  The following resource(s) failed to create: [MasterServerWaitCondition, ComputeFleet].

--- a/parallel_cluster/bin/start_cluster.sh
+++ b/parallel_cluster/bin/start_cluster.sh
@@ -40,7 +40,7 @@ append_ip_to_extra_parameters() {
   local extra_parameters
   extra_parameters="$(echo "$1" | {
                      # Add AccessFrom attribute - output in raw format
-                     jq ".AccessFrom = \"$(get_local_ip)/0\"" \
+                     jq ".AccessFrom = \"$(get_local_ip)/32\"" \
                        --compact-output
                     } | {
                       # Compact output is too compact

--- a/parallel_cluster/bin/sync_config_files.sh
+++ b/parallel_cluster/bin/sync_config_files.sh
@@ -1,8 +1,12 @@
 #!/usr/bin/env bash
 
-ROOT_PATH="umccr-temp-dev/Alexis_parallel_cluster_test"
+ROOT_PATH="umccr-research-dev/parallel-cluster"
 
 aws s3 sync "cromwell/" "s3://${ROOT_PATH}/cromwell/"
 aws s3 sync "bootstrap/" "s3://${ROOT_PATH}/bootstrap/"
 aws s3 sync "bcbio" "s3://${ROOT_PATH}/bcbio/"
 aws s3 sync "slurm/scripts" "s3://${ROOT_PATH}/slurm/scripts"
+aws s3 cp "slurm/conf/slurmdbd-template.conf" "s3://${ROOT_PATH}/slurm/conf/slurmdbd-template.conf"
+# Upload password and end points
+#aws s3 cp "slurm/conf/slurmdbd-endpoint.txt" "s3://${ROOT_PATH}/slurm/conf/slurmdbd-endpoint.txt"
+#aws s3 cp "slurm/conf/slurmdbd-passwd.txt" "s3://${ROOT_PATH}/slurm/conf/slurmdbd-passwd.txt"

--- a/parallel_cluster/bootstrap/post_install.sh
+++ b/parallel_cluster/bootstrap/post_install.sh
@@ -103,7 +103,7 @@ fi
 set -e
 
 # Globals
-S3_BUCKET_DIR="s3://umccr-temp-dev/Alexis_parallel_cluster_test"
+S3_BUCKET_DIR="s3://umccr-research-dev/parallel-cluster"
 # Globals - Miscell
 # Which timezone are we in
 TIMEZONE="Australia/Melbourne"

--- a/parallel_cluster/conf/config
+++ b/parallel_cluster/conf/config
@@ -45,8 +45,8 @@ initial_queue_size    = 1
 # conda has been initialised to the ec2-user
 # See the ami readme for recreation of the custom_ami
 custom_ami            = ami-0309a6a138b994d22
-pre_install           = s3://umccr-temp-dev/Alexis_parallel_cluster_test/bootstrap/pre_install.sh
-post_install          = s3://umccr-temp-dev/Alexis_parallel_cluster_test/bootstrap/post_install.sh
+pre_install           = s3://umccr-research-dev/parallel-cluster/bootstrap/pre_install.sh
+post_install          = s3://umccr-research-dev/parallel-cluster/bootstrap/post_install.sh
 
 [cluster umccr_dev_fsx]
 base_os               = alinux2
@@ -69,8 +69,8 @@ initial_queue_size    = 1
 # conda has been initialised to the ec2-user
 # See the ami readme for recreation of the custom_ami
 custom_ami           = ami-0309a6a138b994d22
-pre_install           = s3://umccr-temp-dev/Alexis_parallel_cluster_test/bootstrap/pre_install.sh
-post_install          = s3://umccr-temp-dev/Alexis_parallel_cluster_test/bootstrap/post_install.sh
+pre_install           = s3://umccr-research-dev/parallel-cluster/bootstrap/pre_install.sh
+post_install          = s3://umccr-research-dev/parallel-cluster/bootstrap/post_install.sh
 
 ## Networks
 [vpc tothill_network]

--- a/parallel_cluster/slurm/conf/.gitignore
+++ b/parallel_cluster/slurm/conf/.gitignore
@@ -1,0 +1,2 @@
+slurmdbd-passwd.txt
+slurmdbd-endpoint.txt

--- a/parallel_cluster/slurm/conf/slurmdbd-endpoint.txt
+++ b/parallel_cluster/slurm/conf/slurmdbd-endpoint.txt
@@ -1,1 +1,0 @@
-# Replace this line with your endpoint

--- a/parallel_cluster/slurm/conf/slurmdbd-passwd.txt
+++ b/parallel_cluster/slurm/conf/slurmdbd-passwd.txt
@@ -1,1 +1,0 @@
-# Replace this line with the password to your rds database

--- a/parallel_cluster/slurm/conf/slurmdbd-template.conf
+++ b/parallel_cluster/slurm/conf/slurmdbd-template.conf
@@ -24,6 +24,6 @@ LogFile=/var/log/slurmdbd.log
 PidFile=/var/run/slurmdbd.pid
 StorageType=accounting_storage/mysql
 StorageUser=admin
-StoragePass=
+StoragePass=                           # Password from RDS console
 StorageHost=                           # Endpoint from RDS console
 StoragePort=3306                       # Port from RDS console


### PR DESCRIPTION
Start_cluster:
Uses AccessFrom to users local IP to restrict access to the cluster from ssh to just them. More for security checks, we don't use ssh access anyway.

Readme:
Added in SSO login issues whilst in pcluster env

All other file changes due to redirection of config files to a new s3 bucket.