### PR TITLE
Fixed umccrise cdk jsii cross-stack resource references

### DIFF
--- a/cdk/apps/umccrise/app.py
+++ b/cdk/apps/umccrise/app.py
@@ -93,7 +93,7 @@ common = CommonStack(
     common_dev_props,
     env=aws_env
 )
-CICDStack(
+cicd = CICDStack(
     app,
     cicd_dev_props['namespace'],
     cicd_dev_props,
@@ -112,6 +112,7 @@ IapTesStack(
     env=aws_env
 )
 slack_dev_props['ecr_name'] = common.ecr_name
+slack_dev_props['cb_project'] = cicd.cb_project
 CodeBuildLambdaStack(
     app,
     slack_dev_props['namespace'],

--- a/cdk/apps/umccrise/stacks/cicd.py
+++ b/cdk/apps/umccrise/stacks/cicd.py
@@ -48,3 +48,8 @@ class CICDStack(core.Stack):
             iam.ManagedPolicy.from_aws_managed_policy_name('AmazonEC2ContainerRegistryPowerUser')
         )
         refdata.grant_read(cb_project)
+        self._cb_project = cb_project
+
+    @property
+    def cb_project(self):
+        return self._cb_project

--- a/cdk/apps/umccrise/stacks/slack.py
+++ b/cdk/apps/umccrise/stacks/slack.py
@@ -48,12 +48,7 @@ class CodeBuildLambdaStack(core.Stack):
 
         ################################################################################
         # Create a reference to the UMCCRise CodeBuild project
-        # TODO: should probably use cross-stack resource references
-        cb_project = cb.Project.from_project_name(
-            self,
-            id='UmccriseCodeBuildProject',
-            project_name=props['codebuild_project_name']
-        )
+        cb_project = props['cb_project']
 
         ################################################################################
         # Create an SNS topic to receive CodeBuild state change events


### PR DESCRIPTION
* With latest cdk version, it does not like to import
  external fragments i.e. `cb.Project.from_project_name(...)`
  return object fragment from jsii reflection. Hence, not
  resolving full object state.
* Related https://github.com/aws/aws-cdk/issues/10234