### PR TITLE
Minor readme changes

### DIFF
--- a/parallel_cluster/README.md
+++ b/parallel_cluster/README.md
@@ -132,6 +132,11 @@ All outputs and logs should be under `/efs/cromwell` (or `/fsx/cromwell`)
 These need to be part of the shared filesystem.
 Jobs are run through a slurm/docker configuration.
 
+### Running through toil
+
+Please look through the [toil README](toil/README.md) or checkout the [examples page](working_examples/toil/gridss-purple-linx-cwl.md)
+for guidance.
+
 ### Installing new software on the cluster
 
 Refer to [the custom AMI README.md](ami/README.md) to include your own (bioinformatics) software.

--- a/parallel_cluster/toil/README.md
+++ b/parallel_cluster/toil/README.md
@@ -11,12 +11,12 @@ sinteractive
 > Create the following directories in your shared filesystem mount (probably /efs)
 
 ```bash
-SHARED_FILESYSTEM_DIR="/efs"
-TOIL_JOB_STORE="${SHARED_FILESYSTEM_DIR}/toil/job-store"
-TOIL_WORKDIR="${SHARED_FILESYSTEM_DIR}/toil/workdir"
-TOIL_TMPDIR="${SHARED_FILESYSTEM_DIR}/toil/tmpdir"
-TOIL_LOG_DIR="${SHARED_FILESYSTEM_DIR}/toil/logs"
-TOIL_OUTPUTS="${SHARED_FILESYSTEM_DIR}/toil/outputs"
+SHARED_DIR="/efs"
+TOIL_JOB_STORE="${SHARED_DIR}/toil/job-store"
+TOIL_WORKDIR="${SHARED_DIR}/toil/workdir"
+TOIL_TMPDIR="${SHARED_DIR}/toil/tmpdir"
+TOIL_LOG_DIR="${SHARED_DIR}/toil/logs"
+TOIL_OUTPUTS="${SHARED_DIR}/toil/outputs"
 ```
 
 ```bash


### PR DESCRIPTION
Links to toil readme, use SHARED_DIR consistently as it's now a default env var.