### PR TITLE
Updated data portal stack to terraform 13

### DIFF
--- a/terraform/stacks/umccr_data_portal/outputs.tf
+++ b/terraform/stacks/umccr_data_portal/outputs.tf
@@ -70,6 +70,10 @@ output "SSM_KEY_NAME_DJANGO_SECRET_KEY" {
   value = aws_ssm_parameter.ssm_key_name_django_secret_key.value
 }
 
+output "SSM_KEY_NAME_METADATA_TRACKING_SHEET_ID" {
+  value = aws_ssm_parameter.ssm_key_name_metadata_tacking_sheet_id.value
+}
+
 output "SSM_KEY_NAME_LIMS_SPREADSHEET_ID" {
   value = aws_ssm_parameter.ssm_key_name_lims_spreadsheet_id.value
 }

--- a/terraform/stacks/umccr_data_portal/variables.tf
+++ b/terraform/stacks/umccr_data_portal/variables.tf
@@ -1,7 +1,7 @@
 variable "base_domain" {
   default = {
     prod = "prod.umccr.org"
-    dev = "dev.umccr.org"
+    dev  = "dev.umccr.org"
   }
   description = "Base domain for current stage"
 }
@@ -9,23 +9,23 @@ variable "base_domain" {
 variable "alias_domain" {
   default = {
     prod = "data.umccr.org"
-    dev = ""
+    dev  = ""
   }
   description = "Additional domains to alias base_domain"
 }
 
 # NOTE:
-# Automatic cert validation required to create records in hosted zone (zone_id), see [1]
-# Since subject alternate name compose of alias_domain, which is hosted in bastion account
-# so, it is not able to automatically create DNS validation record set this way
-# Therefore, cert will be just created and pending DNS validation
-# And requires manually add DNS records for validation, this can be done through ACM Console UI to respective Route53 zones
-# Need to be done once upon a fresh initial deployment
+# Automatic cert validation required to create records in hosted zone (zone_id), see [1].
+# Since subject alternate name compose of alias_domain -- data.umccr.org, which is hosted in BASTION account (i.e required cross-account access).
+# So, from PROD account, it is not able to automatically create DNS validation record set in BASTION Route53 resource.
+# Therefore, cert will be just created and pending DNS validation.
+# And requires manually add DNS records for validation, this can be done through ACM Console UI to respective account Route53 zones.
+# Need to be done only once upon a fresh initial deployment.
 # [1]: https://www.terraform.io/docs/providers/aws/r/acm_certificate_validation.html#alternative-domains-dns-validation-with-route-53
 variable "certificate_validation" {
   default = {
     prod = 0
-    dev = 1
+    dev  = 1
   }
   description = "Whether automatic validate the cert (1) or, to manually validate (0)"
 }
@@ -33,7 +33,7 @@ variable "certificate_validation" {
 variable "s3_primary_data_bucket" {
   default = {
     prod = "umccr-primary-data-prod"
-    dev = "umccr-primary-data-dev"
+    dev  = "umccr-primary-data-dev"
   }
   description = "Name of the S3 bucket storing s3 primary data to be used by crawler "
 }
@@ -41,28 +41,28 @@ variable "s3_primary_data_bucket" {
 variable "s3_run_data_bucket" {
   default = {
     prod = "umccr-run-data-prod"
-    dev = "umccr-run-data-dev"
+    dev  = "umccr-run-data-dev"
   }
   description = "Name of the S3 bucket storing s3 run data to be used by crawler "
 }
 
 variable "github_branch" {
   default = {
-    prod = "master"
-    dev = "dev"
+    prod = "main"
+    dev  = "dev"
   }
   description = "The branch corresponding to current stage"
 }
 
 variable "localhost_url" {
-  default = "http://localhost:3000"
+  default     = "http://localhost:3000"
   description = "The localhost url used for testing"
 }
 
 variable "rds_auto_pause" {
   default = {
     prod = false,
-    dev = false
+    dev  = false
   }
   description = "Whether to keep RDS serverless alive or pause if no load"
 }
@@ -70,7 +70,7 @@ variable "rds_auto_pause" {
 variable "rds_min_capacity" {
   default = {
     prod = 1,
-    dev = 1
+    dev  = 1
   }
   description = "The minimum capacity in Aurora Capacity Units (ACUs)"
 }
@@ -78,7 +78,7 @@ variable "rds_min_capacity" {
 variable "rds_max_capacity" {
   default = {
     prod = 16,
-    dev = 1
+    dev  = 1
   }
   description = "The maximum capacity in Aurora Capacity Units (ACUs)"
 }
@@ -86,7 +86,7 @@ variable "rds_max_capacity" {
 variable "slack_channel" {
   default = {
     prod = "#biobots",
-    dev = "#arteria-dev"
+    dev  = "#arteria-dev"
   }
   description = "Slack channel to send operational status message"
 }


### PR DESCRIPTION
* TF13 comes improved support on AWS provider
* Bump AWS and GitHub providers versions
* Removed deprecated `template_file` data query usage
* Updated to use now-fixed ACM SAN validation ordering setting
* Added SSM param data query: metadata sheet, github token
* Added default tags across the board
* Fixed Cognito ordering
* Added SSE support for buckets
* Updated CodePipeline to use dedicated GitHub token and share HMAC
* Minor refactor and lint
