### PR TITLE
CDK umccrise: Updated CICD stack

### DIFF
--- a/cdk/apps/umccrise/app.py
+++ b/cdk/apps/umccrise/app.py
@@ -41,7 +41,8 @@ common_dev_props = {
 
 cicd_dev_props = {
     'namespace': 'umccrise-cicd',
-    'codebuild_project_name': codebuild_project_name
+    'codebuild_project_name': codebuild_project_name,
+    'refdata_bucket': refdata_bucket,
 }
 
 batch_props = {

--- a/cdk/apps/umccrise/stacks/cicd.py
+++ b/cdk/apps/umccrise/stacks/cicd.py
@@ -16,11 +16,11 @@ class CICDStack(core.Stack):
         refdata = s3.Bucket.from_bucket_attributes(
             self,
             'reference_data',
-            bucket_name='umccr-refdata-dev'
+            bucket_name=props['refdata_bucket'],
         )
 
         build_env = cb.BuildEnvironment(
-            build_image=cb.LinuxBuildImage.from_docker_registry("docker:dind"),
+            build_image=cb.LinuxBuildImage.STANDARD_4_0,
             privileged=True,
             compute_type=cb.ComputeType.LARGE)
 


### PR DESCRIPTION
* Updated CodeBuild to use AWS Standard 4.0 build image
  https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-available.html
* Fixed ref data bucket to get from param store
