### PR TITLE
Portal TF: Added terraform 0.14 dependency lock file

### DIFF
--- a/terraform/stacks/umccr_data_portal/.terraform.lock.hcl
+++ b/terraform/stacks/umccr_data_portal/.terraform.lock.hcl
@@ -1,0 +1,38 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.7.0"
+  constraints = "~> 3.7.0"
+  hashes = [
+    "h1:8QRyqfko4OY8FQfIAvEoOAeiQiP0EVUZk3nsMJXG2Dc=",
+    "zh:261263f20da3e558693d9f963b5d70ebaf7096fe3ec33d011f8f20322d5e02d4",
+    "zh:37892e7634d3ec8a599b86569c32ff7f323e0840a6fde9e4eb82ba7b654c5d86",
+    "zh:54a75bc0c94ed8fefa050a69749440b902cc88731dd312385d5928d23f08b3e1",
+    "zh:620a4944eb60bdd2952477abf9391c5504e17295cb89e9b9b601e7577b037b01",
+    "zh:63ee761ebb01817824816288725ccd722c2e1f2ab0f2645f0a5b0703a599c3bf",
+    "zh:8160670ac718c437b84de43368712387afa979e55cf487c6350252fd93c7eb85",
+    "zh:a6baaa9670e400482f55078c464dc9e9f8a548a4dfc8f3116e94db8686e69f0b",
+    "zh:aaec3b0644b3e523ca1cc8a117362379d213f3bd8906047bfe42c2a633f78a05",
+    "zh:bcae7acf6a6895902e092004a2a6078a664a0457c1a3d0d36589b3aca8e09632",
+    "zh:cb84c9329fc9c7a0dbf17ae656541c322f5679676672b61a59b6726eb0141c88",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/github" {
+  version     = "3.0.0"
+  constraints = "~> 3.0.0"
+  hashes = [
+    "h1:3HJ/J0YjteFtrjz6KWYqKpYHh/2CUUi7MiTZwRa8ssI=",
+    "zh:043081c4c2f8fdeb3d694eb6cd81225c55747ac8b6adec11968aba68dc97c026",
+    "zh:09c6aab8b2b4c7017b8c2d8e1ef0939cc7e7db81e1cca961291251d0bfeb7050",
+    "zh:28109dca3cb62347dffbe03fc923d7db0989f0e0dca3e3f20b8eb2883f21617f",
+    "zh:4af0a15bbc996abc3c20978d600af53143e4f8343b81b76f543c0a926d3a6e82",
+    "zh:876416f2e1445c8e53a84c723d9c2051115a142efa6082d5939ca6371531919b",
+    "zh:9aad918f0295adde2f4752361c93522a975a095b95ec6a331d97587bb586e061",
+    "zh:a977cc85757a8953de32d792993ca38f562edd0d79b3c4bd93021a68f20adc77",
+    "zh:ba384ba916dd8bc0a2c854e16a31d2075f62018a73a60917c89945da07a13fdd",
+    "zh:e870f594225491d6b05b6db05a064e391b42fd8e43576f3254a3f9dbb012b685",
+    "zh:f722f3ca830d59dc30ba25b8b4ab9e77ed229385584f2501275a4321189da54d",
+  ]
+}


### PR DESCRIPTION
* Added TF 0.14 plugins dependency lock file, See
  https://www.terraform.io/docs/configuration/dependency-lock.html
