### PR TITLE
Portal TF: Added AWS Backup for Portal DB Aurora Snapshots

### DIFF
--- a/terraform/stacks/umccr_data_portal/main.tf
+++ b/terraform/stacks/umccr_data_portal/main.tf
@@ -1078,6 +1078,8 @@ resource "aws_rds_cluster" "db" {
     max_capacity = var.rds_max_capacity[terraform.workspace]
   }
 
+  backup_retention_period = var.rds_backup_retention_period[terraform.workspace]
+
   tags = merge(local.default_tags)
 }
 
@@ -1089,6 +1091,83 @@ resource "aws_ssm_parameter" "ssm_full_db_url" {
   value       = "mysql://${data.aws_ssm_parameter.rds_db_username.value}:${data.aws_ssm_parameter.rds_db_password.value}@${aws_rds_cluster.db.endpoint}:${aws_rds_cluster.db.port}/${aws_rds_cluster.db.database_name}"
 
   tags = merge(local.default_tags)
+}
+
+################################################################################
+# AWS Backup configuration for Aurora DB
+
+data "aws_kms_key" "backup" {
+  key_id = "alias/aws/backup"
+}
+
+resource "aws_iam_role" "db_backup_role" {
+  count              = var.create_aws_backup[terraform.workspace]
+  name               = "${local.stack_name_us}_backup_role"
+  assume_role_policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": ["sts:AssumeRole"],
+      "Effect": "allow",
+      "Principal": {
+        "Service": ["backup.amazonaws.com"]
+      }
+    }
+  ]
+}
+POLICY
+
+  tags = merge(local.default_tags)
+}
+
+resource "aws_iam_role_policy_attachment" "db_backup_role_policy" {
+  count      = var.create_aws_backup[terraform.workspace]
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSBackupServiceRolePolicyForBackup"
+  role       = aws_iam_role.db_backup_role[count.index].name
+}
+
+resource "aws_iam_role_policy_attachment" "db_backup_role_restore_policy" {
+  count      = var.create_aws_backup[terraform.workspace]
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSBackupServiceRolePolicyForRestores"
+  role       = aws_iam_role.db_backup_role[count.index].name
+}
+
+resource "aws_backup_vault" "db_backup_vault" {
+  count = var.create_aws_backup[terraform.workspace]
+  name  = "${local.stack_name_us}_backup_vault"
+  kms_key_arn = data.aws_kms_key.backup.arn
+  tags  = merge(local.default_tags)
+}
+
+resource "aws_backup_plan" "db_backup_plan" {
+  count = var.create_aws_backup[terraform.workspace]
+  name  = "${local.stack_name_us}_backup_plan"
+
+  // Backup weekly and keep it for 6 weeks
+  // Cron At 17:00 on every Sunday UTC = AEST/AEDT 3AM/4AM on every Monday
+  rule {
+    rule_name         = "Weekly"
+    target_vault_name = aws_backup_vault.db_backup_vault[count.index].name
+    schedule          = "cron(0 17 ? * SUN *)"
+
+    lifecycle {
+      delete_after = 42
+    }
+  }
+
+  tags = merge(local.default_tags)
+}
+
+resource "aws_backup_selection" "db_backup" {
+  count        = var.create_aws_backup[terraform.workspace]
+  name         = "${local.stack_name_us}_backup"
+  plan_id      = aws_backup_plan.db_backup_plan[count.index].id
+  iam_role_arn = aws_iam_role.db_backup_role[count.index].arn
+
+  resources = [
+    aws_rds_cluster.db.arn,
+  ]
 }
 
 ################################################################################

--- a/terraform/stacks/umccr_data_portal/variables.tf
+++ b/terraform/stacks/umccr_data_portal/variables.tf
@@ -61,7 +61,7 @@ variable "localhost_url" {
 
 variable "rds_auto_pause" {
   default = {
-    prod = false,
+    prod = false
     dev  = false
   }
   description = "Whether to keep RDS serverless alive or pause if no load"
@@ -69,7 +69,7 @@ variable "rds_auto_pause" {
 
 variable "rds_min_capacity" {
   default = {
-    prod = 1,
+    prod = 1
     dev  = 1
   }
   description = "The minimum capacity in Aurora Capacity Units (ACUs)"
@@ -77,10 +77,26 @@ variable "rds_min_capacity" {
 
 variable "rds_max_capacity" {
   default = {
-    prod = 16,
+    prod = 16
     dev  = 1
   }
   description = "The maximum capacity in Aurora Capacity Units (ACUs)"
+}
+
+variable "rds_backup_retention_period" {
+  default = {
+    prod = 7
+    dev  = 1
+  }
+  description = "RDS Aurora managed automated backup, must have 1 at least for Aurora Serverless DB"
+}
+
+variable "create_aws_backup" {
+  default = {
+    prod = 1
+    dev  = 0
+  }
+  description = "Create AWS Backup for RDS Aurora Serverless DB, 1 create, 0 not"
 }
 
 variable "slack_channel" {


### PR DESCRIPTION
* AWS Backup now support Aurora, See
  https://aws.amazon.com/about-aws/whats-new/2020/06/amazon-aurora-snapshots-can-be-managed-via-aws-backup/
* Increased automated backup retention period 7 days
* Set AWS Backup for Portal Aurora DB weekly snapshots
  and retain up to 6 weeks then rotate
* Backup configured only for PROD
