### PR TITLE
Htsget CDK: Added GA4GH Passport support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ __pycache__
 .idea/
 .dev
 dev/
+.build/

--- a/cdk/apps/htsget/Makefile
+++ b/cdk/apps/htsget/Makefile
@@ -1,0 +1,13 @@
+install:
+	@pip install -r requirements.txt
+
+test:
+	@(cd lambdas/ppauthz && python -m unittest)
+
+deploy:
+	@(cdk diff && cdk deploy --all)
+
+refresh:
+	@rm -rf lambdas/.build
+
+refresh_deploy: refresh deploy

--- a/cdk/apps/htsget/Makefile
+++ b/cdk/apps/htsget/Makefile
@@ -4,8 +4,11 @@ install:
 test:
 	@(cd lambdas/ppauthz && python -m unittest)
 
-deploy:
-	@(cdk diff && cdk deploy --all)
+diff:
+	@cdk diff
+
+deploy: diff
+	@cdk deploy --all
 
 refresh:
 	@rm -rf lambdas/.build

--- a/cdk/apps/htsget/README.md
+++ b/cdk/apps/htsget/README.md
@@ -16,8 +16,9 @@ cdk destroy
 
 ## Architecture
 ```
-  ACM
-   |      (authz)             |           [private subnets]
+        GA4GH Passport                       GA4GH htsget
+  ACM        |                                     |
+   |   (Lambda Authz)         |           (private subnets)
 Route53 > APIGWv2 > VpcLink > | ALB > (autoscaling) ECS Fargate Cluster
                               |
 ```
@@ -56,3 +57,47 @@ Alternatively, use AWS SSM Console UI.
     aws ssm put-parameter --name '/htsget/refserver/config' --type String --tier Advanced --value file://config/dev.json --overwrite
     ```
 2. Terminate any existing running `htsget-refserver` main containers
+
+
+## Lambda Development
+
+
+[GA4GH Passport Clearinghouse](https://github.com/ga4gh-duri/ga4gh-duri.github.io/blob/master/researcher_ids/ga4gh_passport_v1.md) is implemented as AWS API Gateway v2's [Lambda Authorizer](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-lambda-authorizer.html). 
+
+- **TL;DR** dev workflow:
+    ```
+    make test
+    make deploy
+    ```
+
+- This lambda authorizer Python module is inside [lambdas/ppauthz](lambdas/ppauthz).
+
+- For current trusted Passport Brokers, see `TRUSTED_BROKERS` module variable in [ppauthz.py](lambdas/ppauthz/ppauthz.py).
+   
+    > 🙋‍♂️ You will need to have compliant Passport Visa Token from this list of trusted brokers; in order to call UMCCR *secured* htsget endpoints.
+
+- To run tests:
+  
+    **TL;DR:**
+    ```
+    make test
+    ```
+
+    ```
+    cd lambdas/ppauthz
+    python -m unittest
+    python -m unittest test_ppauthz.PassportAuthzUnitTest.test_handler
+    python -m unittest test_ppauthz.PassportAuthzIntegrationTest.test_handler_it
+    ```
+    > 🙋‍♂️Read more in the PyDoc string!
+
+- If you update this [lambdas/requirements.txt](lambdas/requirements.txt) file:
+  
+    **TL;DR:**
+    ```
+    make refresh_deploy
+    ```
+  
+    If you update Lambda Python dependency, make sure to delete [lambdas/.build](lambdas/.build) staging directory. Before applying `cdk diff && cdk deploy`.
+    
+    > 🙋‍♂️ Lambda Python dependency is packaged and deployed as Lambda Layer. It contains **platform dependant cryptography** library. Hence, required AWS Lambda Docker image to build and packaging it!

--- a/cdk/apps/htsget/htsget/goserver.py
+++ b/cdk/apps/htsget/htsget/goserver.py
@@ -328,7 +328,7 @@ class GoServerStack(core.Stack):
         # Setup Python dependencies as Lambda layer
         if not os.path.exists(lmbda_deps_out):
             dkr_client = docker.from_env()
-            dkr_image = dkr_client.images.pull(repository="lambci/lambda", tag="build-python3.7")
+            dkr_image = dkr_client.images.pull(repository="lambci/lambda", tag="build-python3.8")
             cmd = f"pip install -r {lmbda_deps_file} -t {lmbda_deps_out}/python"
             dkr_client.containers.run(
                 image=dkr_image.tags[0],
@@ -347,7 +347,7 @@ class GoServerStack(core.Stack):
             "PassportAuthzLambda",
             function_name=function_name,
             handler="ppauthz.handler",
-            runtime=lmbda.Runtime.PYTHON_3_7,
+            runtime=lmbda.Runtime.PYTHON_3_8,
             code=lmbda.Code.from_asset("lambdas/ppauthz"),
             timeout=core.Duration.seconds(20),
             layers=[

--- a/cdk/apps/htsget/htsget/goserver.py
+++ b/cdk/apps/htsget/htsget/goserver.py
@@ -397,17 +397,25 @@ class GoServerStack(core.Stack):
 
         # --- Add protected endpoint routes in ApiGatewayv2 HttpApi for secured data serving with htsget backend!
 
-        # Add route protected with GA4GH Passport
-        rt_protected_pp = apigwv2.HttpRoute(
-            self,
-            "PassportProtectedRoute",
-            http_api=self.http_api,
-            route_key=apigwv2.HttpRouteKey.with_(
-                path="/reads/giab.NA12878.NIST7086.2",
-                method=apigwv2.HttpMethod.ANY
-            ),
-            integration=self.apigwv2_alb_integration
-        )
-        rt_protected_pp_cfn: apigwv2.CfnRoute = rt_protected_pp.node.default_child
-        rt_protected_pp_cfn.authorizer_id = authzr.ref
-        rt_protected_pp_cfn.authorization_type = "CUSTOM"
+        # Add route to protected resources with GA4GH Passport
+        resources = [
+            "/reads/giab.NA12878.NIST7086.2",
+            "/reads/data/giab.NA12878.NIST7086.2",
+            "/variants/giab.NA12878",
+            "/variants/data/giab.NA12878",
+        ]
+
+        for idx, res in enumerate(resources, start=1):
+            rt_protected_pp = apigwv2.HttpRoute(
+                self,
+                f"PassportProtectedRoute{idx}",
+                http_api=self.http_api,
+                route_key=apigwv2.HttpRouteKey.with_(
+                    path=f"{res}",
+                    method=apigwv2.HttpMethod.ANY
+                ),
+                integration=self.apigwv2_alb_integration
+            )
+            rt_protected_pp_cfn: apigwv2.CfnRoute = rt_protected_pp.node.default_child
+            rt_protected_pp_cfn.authorizer_id = authzr.ref
+            rt_protected_pp_cfn.authorization_type = "CUSTOM"

--- a/cdk/apps/htsget/lambdas/ppauthz/ppauthz.py
+++ b/cdk/apps/htsget/lambdas/ppauthz/ppauthz.py
@@ -1,0 +1,145 @@
+import json
+import re
+from datetime import datetime, timedelta
+
+import jwt
+import requests
+from jwt import algorithms as jwt_algo
+
+ALLOWED_AUDIENCE = [
+    "htsget.dev.umccr.org",
+    "htsget.umccr.org",
+]
+
+TRUSTED_BROKERS = {
+    'https://guppy.sandbox.genovic.org.au': {
+        'well_known': "/.well-known/openid-configuration",
+        'alg': "RS256",
+        'token_age_seconds': 3600,
+    },
+    'https://issuer1.sandbox.genovic.org.au': {
+        'well_known': "/.well-known/openid-configuration",
+        'alg': "RS256",
+        'token_age_seconds': 3600,
+    },
+    'https://issuer2.sandbox.genovic.org.au': {
+        'well_known': "/.well-known/openid-configuration",
+        'alg': "RS256",
+        'token_age_seconds': 3600,
+    },
+}
+
+
+def raise_error(message: dict):
+    print(json.dumps(message))
+    raise ValueError(message)
+
+
+def extract_token(event) -> str:
+    """
+    Extract authorization from AWS Lambda authorizer headers. See Payload format for version 2.0
+    https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-lambda-authorizer.html
+
+    :param event:
+    :return:
+    """
+    authz_header: str = event['headers']['authorization']
+
+    if not re.search("^Bearer", authz_header, re.IGNORECASE):
+        raise_error({'message': "No Bearer found in authorization header"})
+
+    authz_header = re.sub("^Bearer", "", authz_header, flags=re.IGNORECASE).strip()
+
+    return authz_header
+
+
+def verify_jwt_structure(encoded_jwt) -> bool:
+    """
+    Check that JWT structure has 3 sections: header, payload, signature
+
+    :param encoded_jwt:
+    :return:
+    """
+    if len(encoded_jwt.split(".")) != 3:
+        raise_error({'message': "Not a valid JWT"})
+    return True
+
+
+def get_verified_jwt_claims(encoded_jwt):
+    unverified_header = jwt.get_unverified_header(encoded_jwt)
+    unverified_payload = jwt.decode(encoded_jwt, options={'verify_signature': False})
+
+    kid = unverified_header['kid']
+    iss = unverified_payload['iss']
+    exp = unverified_payload['exp']
+    iat = unverified_payload['iat']
+    aud = unverified_payload.get('aud')
+
+    if iss not in TRUSTED_BROKERS.keys():
+        raise_error({'message': f"Found untrusted broker: {iss}"})
+
+    now_dt = datetime.now()
+
+    exp_dt = datetime.fromtimestamp(exp)
+    if now_dt > exp_dt:
+        raise_error({'message': f"Token has expired since {exp_dt.astimezone().isoformat()}"})
+
+    iat_dt = datetime.fromtimestamp(iat)
+    token_age = TRUSTED_BROKERS[iss]['token_age_seconds']
+    if timedelta.total_seconds(now_dt - iat_dt) > token_age:
+        raise_error({'message': f"Token is too old. It has issued since {iat_dt.astimezone().isoformat()}. "
+                                f"Allowed token age is {token_age} seconds."})
+
+    if aud is not None and aud not in ALLOWED_AUDIENCE:
+        raise_error({'message': f"Found unrecognised audience claim: {aud}"})
+
+    well_known_config = requests.get(iss + TRUSTED_BROKERS[iss]['well_known']).json()
+    jwks_uri = well_known_config['jwks_uri']
+    jwks = requests.get(jwks_uri).json()
+
+    public_keys = {}
+    for jwk in jwks['keys']:
+        _kid: str = jwk['kid']
+        _alg: str = jwk['alg']
+        if _alg.startswith('RS'):
+            public_keys[_kid] = jwt_algo.RSAAlgorithm.from_jwk(json.dumps(jwk))
+        elif _alg.startswith('ES'):
+            public_keys[_kid] = jwt_algo.ECAlgorithm.from_jwk(json.dumps(jwk))
+        elif _alg.startswith('HS'):
+            public_keys[_kid] = jwt_algo.HMACAlgorithm.from_jwk(json.dumps(jwk))
+        else:
+            raise_error({'message': f"Unsupported signing algorithm: {_alg}"})
+
+    public_key = public_keys[kid]
+    payload = jwt.decode(encoded_jwt, key=public_key, algorithms=[TRUSTED_BROKERS[iss]['alg']])
+    return payload
+
+
+def handler(event, context):
+    """Lambda handler entrypoint for GA4GH Passport Clearinghouse for htsget endpoint authz"""
+
+    is_authorized = False
+
+    encoded_token = extract_token(event)
+    verify_jwt_structure(encoded_token)
+    claims = get_verified_jwt_claims(encoded_token)
+
+    ga4gh_visa_v1 = claims['ga4gh_visa_v1']
+    visa_type = ga4gh_visa_v1['type']
+    visa_asserted = ga4gh_visa_v1['asserted']
+    visa_value = ga4gh_visa_v1['value']
+    visa_source = ga4gh_visa_v1['source']
+    visa_by: str = ga4gh_visa_v1.get('by', "null")
+
+    # TODO ACL access rule?
+    if visa_type == "ControlledAccessGrants" and "umccr" in visa_value:
+        is_authorized = True
+
+    authz_resp = {
+        'isAuthorized': is_authorized,
+        'context': {
+            'visa_by': str(visa_by)
+        }
+    }
+
+    return authz_resp

--- a/cdk/apps/htsget/lambdas/ppauthz/test_ppauthz.py
+++ b/cdk/apps/htsget/lambdas/ppauthz/test_ppauthz.py
@@ -77,8 +77,9 @@ class PassportAuthzUnitTest(TestCase):
         cd lambdas/ppauthz
         python -m unittest test_ppauthz.PassportAuthzUnitTest.test_handler
         """
-        with self.assertRaises(ValueError):
-            ppauthz.handler(self.mock_event, None)
+        lmbda_resp = ppauthz.handler(self.mock_event, None)
+        print(lmbda_resp)
+        self.assertFalse(lmbda_resp['isAuthorized'])
 
 
 class PassportAuthzIntegrationTest(TestCase):

--- a/cdk/apps/htsget/lambdas/ppauthz/test_ppauthz.py
+++ b/cdk/apps/htsget/lambdas/ppauthz/test_ppauthz.py
@@ -1,0 +1,103 @@
+import os
+from unittest.case import TestCase
+
+import ppauthz
+
+INVALID_TOKEN = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6InNvbWVraWQxIn0.eyJpc3MiOiJodHRwczovL2lzczEudW1jY3Iub3JnIiwic3ViIjoiMTIzNDU2Nzg5MCIsIm5hbWUiOiJKb2huIERvZSIsImlhdCI6MTUxNjIzOTAyMiwiZXhwIjoxNTE2MjM5MDIyLCJnYTRnaF92aXNhX3YxIjp7InR5cGUiOiJDb250cm9sbGVkQWNjZXNzR3JhbnRzIiwiYXNzZXJ0ZWQiOjE1NDk2MzI4NzIsInZhbHVlIjoiaHR0cHM6Ly91bWNjci5vcmcvaW52YWxpZC8xIiwic291cmNlIjoiaHR0cHM6Ly9ncmlkLmFjL2luc3RpdHV0ZXMvZ3JpZC4wMDAwLjBhIiwiYnkiOiJkYWMifX0.5DIqppX02Rkw2Ebk4KgvPlbKVBwS1dPiSeLaLLQDjBg"
+
+
+def make_mock_event(mock_token):
+    return {
+        "version": "2.0",
+        "type": "REQUEST",
+        "routeArn": "arn:aws:execute-api:ap-southeast-2:123456789:aaa1gggcct/$default/GET/reads/giab.NA12878.NIST7086.1",
+        "identitySource": [
+            f"Bearer {mock_token}"
+        ],
+        "routeKey": "ANY /reads/giab.NA12878.NIST7086.1",
+        "rawPath": "/reads/giab.NA12878.NIST7086.1",
+        "rawQueryString": "",
+        "headers": {
+            "accept": "*/*",
+            "authorization": f"Bearer {mock_token}",
+            "content-length": "0",
+            "host": "htsget.some.org",
+            "user-agent": "curl/7.69.1",
+            "x-amzn-trace-id": "Root=1-600f56db-41dc5dac31f68e8253bbb29a",
+            "x-forwarded-for": "111.222.333.444",
+            "x-forwarded-port": "443",
+            "x-forwarded-proto": "https"
+        },
+        "requestContext": {
+            "accountId": "123456789",
+            "apiId": "aaa1gggcct",
+            "domainName": "htsget.some.org",
+            "domainPrefix": "htsget",
+            "http": {
+                "method": "GET",
+                "path": "/reads/giab.NA12878.NIST7086.1",
+                "protocol": "HTTP/1.1",
+                "sourceIp": "111.222.333.444",
+                "userAgent": "curl/7.69.1"
+            },
+            "requestId": "ZuqGrHudSwMEP4w=",
+            "routeKey": "ANY /reads/giab.NA12878.NIST7086.1",
+            "stage": "$default",
+            "time": "25/Jan/2021:23:40:11 +0000",
+            "timeEpoch": 1611618011254
+        }
+    }
+
+
+class PassportAuthzUnitTest(TestCase):
+
+    def setUp(self) -> None:
+        self.mock_token = INVALID_TOKEN
+        self.mock_event = make_mock_event(self.mock_token)
+
+    def test_extract_token(self):
+        """
+        cd lambdas/ppauthz
+        python -m unittest test_ppauthz.PassportAuthzUnitTest.test_extract_token
+        """
+        tok = ppauthz.extract_token(self.mock_event)
+        print(tok)
+        self.assertEqual(tok, self.mock_token)
+
+    def test_verify_jwt_structure(self):
+        """
+        cd lambdas/ppauthz
+        python -m unittest test_ppauthz.PassportAuthzUnitTest.test_verify_jwt_structure
+        """
+        tok = ppauthz.extract_token(self.mock_event)
+        self.assertTrue(ppauthz.verify_jwt_structure(tok))
+
+    def test_handler(self):
+        """
+        cd lambdas/ppauthz
+        python -m unittest test_ppauthz.PassportAuthzUnitTest.test_handler
+        """
+        with self.assertRaises(ValueError):
+            ppauthz.handler(self.mock_event, None)
+
+
+class PassportAuthzIntegrationTest(TestCase):
+
+    def setUp(self) -> None:
+        self.mock_token = os.getenv('PASSPORT_VISA_TOKEN')
+        self.mock_event = make_mock_event(self.mock_token)
+
+    def test_handler_it(self):
+        """Login to Labtec to grab fresh visa token and export as PASSPORT_VISA_TOKEN env var. Ignore IT test otherwise!
+        Login Labtec > Userinfo -> ga4gh_passport_v1 -> Copy first visa token (i.e meant for umccr, check with Andrew)
+        Then, export the passport visa token
+
+            export PASSPORT_VISA_TOKEN=eyJ0...
+
+        Then, run the test
+
+            cd lambdas/ppauthz
+            python -m unittest test_ppauthz.PassportAuthzIntegrationTest.test_handler_it
+        """
+        lmbda_resp: dict = ppauthz.handler(self.mock_event, None)
+        self.assertTrue(lmbda_resp['isAuthorized'])

--- a/cdk/apps/htsget/lambdas/requirements.txt
+++ b/cdk/apps/htsget/lambdas/requirements.txt
@@ -1,0 +1,3 @@
+PyJWT==2.0.1
+cryptography==3.3.1
+requests==2.25.1

--- a/cdk/apps/htsget/requirements.txt
+++ b/cdk/apps/htsget/requirements.txt
@@ -1,1 +1,2 @@
+-r lambdas/requirements.txt
 -e .

--- a/cdk/apps/htsget/setup.py
+++ b/cdk/apps/htsget/setup.py
@@ -17,6 +17,7 @@ setuptools.setup(
     packages=setuptools.find_packages(where="htsget"),
 
     install_requires=[
+        "docker",
         "aws-cdk.core",
         "aws-cdk.aws_ec2",
         "aws-cdk.aws_ecs",
@@ -29,6 +30,7 @@ setuptools.setup(
         "aws-cdk.aws_elasticloadbalancingv2",
         "aws-cdk.aws_apigatewayv2",
         "aws-cdk.aws_apigatewayv2_integrations",
+        "aws-cdk.aws_lambda",
     ],
 
     python_requires=">=3.6",


### PR DESCRIPTION
* Added Lambda authorizer as well as built-in AWS_IAM authorizer
  to API Gateway v2 for some experimental htsget endpoints
* Passport Clearinghouse is implemented as AWS Lambda function
* Updated CDK deployment: include Lambda and Lambda Layer for
  Python dependencies packaging
* Updated CDK deployment: added experimental htsget routes to
  collab work with Guppy/Asha genovic.org.au Passport Brokers
* Updated README for Lambda Development
