### PR TITLE
Pull token for GH provider from SSM instead of local envvar

### DIFF
--- a/terraform/stacks/umccr_data_portal/.terraform.lock.hcl
+++ b/terraform/stacks/umccr_data_portal/.terraform.lock.hcl
@@ -19,6 +19,23 @@ provider "registry.terraform.io/hashicorp/aws" {
   ]
 }
 
+provider "registry.terraform.io/hashicorp/external" {
+  version = "2.0.0"
+  hashes = [
+    "h1:6S7hqjmUnoAZ5D/0F1VlJZKSJsUIBh7Ro0tLjGpKO0g=",
+    "zh:07949780dd6a1d43e7b46950f6e6976581d9724102cb5388d3411a1b6f476bde",
+    "zh:0a4f4636ff93f0644affa8474465dd8c9252946437ad025b28fc9f6603534a24",
+    "zh:0dd7e05a974c649950d1a21d7015d3753324ae52ebdd1744b144bc409ca4b3e8",
+    "zh:2b881032b9aa9d227ac712f614056d050bcdcc67df0dc79e2b2cb76a197059ad",
+    "zh:38feb4787b4570335459ca75a55389df1a7570bdca8cdf5df4c2876afe3c14b4",
+    "zh:40f7e0aaef3b1f4c2ca2bb1189e3fe9af8c296da129423986d1d99ccc8cfb86c",
+    "zh:56b361f64f0f0df5c4f958ae2f0e6f8ba192f35b720b9d3ae1be068fabcf73d9",
+    "zh:5fadb5880cd31c2105f635ded92b9b16f918c1dd989627a4ce62c04939223909",
+    "zh:61fa0be9c14c8c4109cfb7be8d54a80c56d35dbae49d3231cddb59831e7e5a4d",
+    "zh:853774bf97fbc4a784d5af5a4ca0090848430781ae6cfc586adeb48f7c44af79",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/github" {
   version     = "3.0.0"
   constraints = "~> 3.0.0"

--- a/terraform/stacks/umccr_data_portal/main.tf
+++ b/terraform/stacks/umccr_data_portal/main.tf
@@ -34,9 +34,8 @@ provider "aws" {
 }
 
 provider "github" {
-  # Token to be provided by GITHUB_TOKEN env variable
-  # (i.e. export GITHUB_TOKEN=xxx)
   organization = "umccr"
+  token        = data.external.get_gh_token_from_ssm.result.gh_token
 }
 
 data "aws_region" "current" {}
@@ -94,6 +93,14 @@ locals {
 
   github_repo_client = "data-portal-client"
   github_repo_apis   = "data-portal-apis"
+}
+
+data "external" "get_gh_token_from_ssm" {
+  program = ["${path.module}/scripts/get_gh_token_from_ssm.sh"]
+  query = {
+    # reusing the PAT token, but could use dedicated token with narrow scope
+    ssm_param_name = "/${local.stack_name_us}/github/pat_oauth_token"
+  }
 }
 
 ################################################################################

--- a/terraform/stacks/umccr_data_portal/scripts/get_gh_token_from_ssm.sh
+++ b/terraform/stacks/umccr_data_portal/scripts/get_gh_token_from_ssm.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+
+# jq reads from stdin so we don't have to set up any inputs, but let's validate the outputs
+eval "$(jq -r '@sh "export SSM_PARAM_NAME=\(.ssm_param_name)"')"
+if [[ -z "${SSM_PARAM_NAME}" ]]; then export SSM_PARAM_NAME=none; fi
+
+gh_token=$(aws ssm get-parameter --name "${SSM_PARAM_NAME}" --output text --query Parameter.Value --with-decryption)
+
+echo "{\"gh_token\": \"$gh_token\"}"


### PR DESCRIPTION
Remove the need to have a local GH token and pull it instead from SSM ParameterStore.