### PR TITLE
Htsget CDK: Added Cognito JWT Authorizer

### DIFF
--- a/cdk/apps/htsget/app.py
+++ b/cdk/apps/htsget/app.py
@@ -11,7 +11,7 @@ aws_env = {'account': account_id, 'region': aws_region}
 
 htsget_props = {
     'namespace': "htsget-refserver",
-    'htsget_refserver_image_tag': "1.4.1_1",
+    'htsget_refserver_image_tag': "1.4.1_2",
     'cors_allowed_origins':  ["https://data.umccr.org", "https://data.dev.umccr.org"],
 }
 

--- a/cdk/apps/htsget/config/dev.json
+++ b/cdk/apps/htsget/config/dev.json
@@ -31,6 +31,10 @@
           {
             "pattern": "^gatk\\.(?P<accession>.*)$",
             "path": "./data/gcp/gatk-test-data/wgs_bam/{accession}.bam"
+          },
+          {
+            "pattern": "^umccr-primary-data(?P<accession>.*)$",
+            "path": "s3://umccr-primary-data{accession}"
           }
         ]
       },
@@ -47,7 +51,7 @@
         "createdAt": "2019-09-15T12:00:00Z",
         "updatedAt": "2020-09-04T14:40:00Z",
         "environment": "production",
-        "version": "1.4.1_1"
+        "version": "1.4.1_2"
       }
     },
     "variants": {
@@ -85,7 +89,7 @@
         "createdAt": "2020-08-31T08:00:00Z",
         "updatedAt": "2020-09-04T14:40:00Z",
         "environment": "production",
-        "version": "1.4.1_1"
+        "version": "1.4.1_2"
       }
     }
   }


### PR DESCRIPTION
* Updated htsget catchall endpoint to use Cognito JWT Authorizer
  NOTE: igv.js internal xhr request pretty much fixed constraint to
  oauth JWT bearer token. Hence, not much room for AWS_IAM Authorizer
  to work around. Luckily, APIGateway & Cognito support JWT oauth flow!
* Bumped htsget-refserver version which added support read, list S3
  objects buckets through secured Go AWS SDK calls. Also support allowing
  embedded `/` characters as part of htsget ID. See ID requirement --
  http://samtools.github.io/hts-specs/htsget.html
  NOTE: Embedded slash is REST anti-pattern however. This is workaround
  until we find a better resource ID resolution service (DRS?) or some form
  of SQL data source registry lookup support directly into htsget-refserver Go impl.
