### PR TITLE
Mapped production project and workgroup to dev t/n workflow

### DIFF
--- a/terraform/stacks/umccr_data_portal/workflow/main.tf
+++ b/terraform/stacks/umccr_data_portal/workflow/main.tf
@@ -152,7 +152,7 @@ locals {
 
   tumor_normal_wfl_version = {
     dev  = "3.7.5"
-    prod = "3.7.5"
+    prod = "3.7.5--5a56dd"
   }
 
   tumor_normal_input = {

--- a/terraform/stacks/umccr_data_portal/workflow/main.tf
+++ b/terraform/stacks/umccr_data_portal/workflow/main.tf
@@ -146,13 +146,13 @@ locals {
   }
 
   tumor_normal_wfl_id = {
-    dev  = "wfl.6e92b9d898a64e7482dc2dfd74e2745d"
-    prod = "wfl.xxx"
+    dev  = "wfl.32e346cdbb854f6487e7594ec17a81f9"
+    prod = "wfl.32e346cdbb854f6487e7594ec17a81f9"
   }
 
   tumor_normal_wfl_version = {
     dev  = "3.7.5"
-    prod = "3.7.5--xxx"
+    prod = "3.7.5"
   }
 
   tumor_normal_input = {


### PR DESCRIPTION
Moved over to dev workflow to project based through the cwl-ica repo. Took the fastest approach.

A couple of issues here:

1. Prod version not GIT version controlled, I cannot create a workflow in the prod project because I do not have permissions.  
2. I am unsure if this workflow should be in the workgroup or project. Are we launching all future runs through projects?

For now I have updated the dev project workflow that @skanwal ported over to the cwl-ica repo to also be part of the dev and prod workgroups and dev and prod projects (for workflow and workflow versions) through updating the acl parameter on the cli.

A couple of solution options to the issues raised above:

1. I clone the definition / re-pack on cwl-ica and then manually create a  workflow version for the production workgroup, then update the acl so that the workflow and the workflow version can be seen by the production project.  

2. We create a 'scoped' token with the scopes [here](https://github.com/umccr/cwl-ica/blob/beta-release/src/utils/globals.py#L12-L54). The token would not have write (or even read access) to production data.  I can then manage the workflows through the cwl-ica repo.  



