### PR TITLE
Rolled back from 'ica' namespace to 'iap' namespace

### DIFF
--- a/terraform/stacks/umccr_data_portal/workflow/main.tf
+++ b/terraform/stacks/umccr_data_portal/workflow/main.tf
@@ -152,7 +152,7 @@ locals {
 
   tumor_normal_wfl_version = {
     dev  = "3.7.5"
-    prod = "3.7.5--a921b06"
+    prod = "3.7.5--2490453"
   }
 
   tumor_normal_input = {


### PR DESCRIPTION
Sorry, will get my terraform config sorted soon enough. This one still needs to be applied.