### PR TITLE
Htsget CDK: Added support for Passport Token

### DIFF
--- a/cdk/apps/htsget/HTSGET_PASSPORT.md
+++ b/cdk/apps/htsget/HTSGET_PASSPORT.md
@@ -43,12 +43,27 @@
 
 ## Use Case: with API
 
-- First, get your Passport's Visa token from Labtec; the one with `Data: https://umccr.org/datasets/710` (tip: typically the first visa)
+#### VISA token
+
+- First, get your Passport's Visa token from Labtec Portal. The one with stamp on `Data: https://umccr.org/datasets/710` visa. Typically, it is the _first_ VISA token at `/userinfo` section in Labtec Portal.
 
 - Export this Visa token as follows:
 ```
 export VISA_TOKEN=eyJ0eXAiOiJKV1QiLC[...shorten...it...for...brevity]tvE07D6g8sQ
 ```
+
+#### PASSPORT token
+
+> **UPDATE:** You may also use the PASSPORT token that contains one valid VISA embedded in the PASSPORT token. See [discussion in PR#43](https://github.com/ga4gh/data-security/pull/43) for context.
+
+- In this case, you would not need to worry about which VISA token but just pass-in the PASSPORT token (assuming it already has a valid VISA stamped-on). Typically, token denotes with `/aai/token` section in Labtec Portal.
+
+- Then, similarly export this Passport token as follows:
+```
+export PASSPORT_TOKEN=eyJ0eXAiOiJKV1QiLC[...shorten...it...for...brevity]tvE07D6g8sQ
+```
+
+- And, change from `$VISA_TOKEN` to `$PASSPORT_TOKEN` in the followings `curl` commands.
 
 ### Alignment BAM Slice
 

--- a/cdk/apps/htsget/lambdas/ppauthz/test_ppauthz.py
+++ b/cdk/apps/htsget/lambdas/ppauthz/test_ppauthz.py
@@ -1,5 +1,5 @@
 import os
-from unittest.case import TestCase
+from unittest.case import TestCase, skip
 
 import ppauthz
 
@@ -83,20 +83,16 @@ class PassportAuthzUnitTest(TestCase):
 
 
 class PassportAuthzIntegrationTest(TestCase):
+    # Integration tests will hit actual endpoints
 
     def setUp(self) -> None:
         self.mock_token = os.getenv('PASSPORT_VISA_TOKEN')
         self.mock_event = make_mock_event(self.mock_token)
 
+    @skip
     def test_handler_it(self):
-        """Login to Labtec to grab fresh visa token and export as PASSPORT_VISA_TOKEN env var. Ignore IT test otherwise!
-        Login Labtec > Userinfo -> ga4gh_passport_v1 -> Copy first visa token (i.e meant for umccr, check with Andrew)
-        Then, export the passport visa token
-
-            export PASSPORT_VISA_TOKEN=eyJ0...
-
+        """Login to Labtec to get passport or visa token and export as PASSPORT_VISA_TOKEN env var.
         Then, run the test
-
             cd lambdas/ppauthz
             python -m unittest test_ppauthz.PassportAuthzIntegrationTest.test_handler_it
         """


### PR DESCRIPTION
* Allowed user to have a choice of passing in VISA or PASSPORT
  token from Labtec Portal
* Added support for Passport token from `/aai/token` endpoint
  See https://github.com/ga4gh/data-security/pull/43
* Updated broker rename: guppy to asha
