### PR TITLE
Updated bclconvert workflow version in prod

### DIFF
--- a/terraform/stacks/umccr_data_portal/workflow/main.tf
+++ b/terraform/stacks/umccr_data_portal/workflow/main.tf
@@ -40,7 +40,7 @@ locals {
 
   bcl_convert_wfl_version = {
     dev  = "3.7.5"
-    prod = "3.7.5--1d8fe7b"
+    prod = "3.7.5--f1e67a3"
   }
 
   bcl_convert_input = {


### PR DESCRIPTION
* Reflects changes to using new multiqc module in workflow for bclconvert

Multiqc is now version 1.11 and supports BCLConvert, we no longer need to use the umccr/multiqc-bclconvert docker container, or set requirements for the tool from in the workflow step.

See:
* https://github.com/umccr/cwl-ica/commit/8d43f489f4cdfa47537ba031167358563fd11511#diff-e03f1a7d569adeb1d1ed75c4f0b25bbd378993a0c7e40a740fe9c96182bcd5f1
* https://github.com/umccr/cwl-ica/commit/8d43f489f4cdfa47537ba031167358563fd11511#diff-0a1b72aa3d9fd894258c0d638ee18e0c9ab874bf33495e996082e7522d87304d
And then https://github.com/umccr/cwl-ica/commit/f1e67a32091e757a85948263afd37d1532b57fb8#diff-e03f1a7d569adeb1d1ed75c4f0b25bbd378993a0c7e40a740fe9c96182bcd5f1

Also note there was a bug in the cwl-ica software that synced an existing production version when the cwl-ica sync command is run locally! See https://github.com/umccr/cwl-ica/commit/8d43f489f4cdfa47537ba031167358563fd11511#diff-b47734da5a8e4c08b51d28d2b39f874c872377c258d5fecc1d5072c93b2572dfR355-R357 

Fortunately we're not using that particular version in prod anyway so I've just patched the issue* and have not reverted that version. We can always 'send it to the graveyard' in future anyway

* Patch here: https://github.com/umccr/cwl-ica/commit/7dfcf8a9affce3d667c53f95e239bf4cba8a81f9#diff-25a6634263c1b1f6fc4697a04e2b9904ea4b042a89af59dc93ec1f5d44848a26