### PR TITLE
Portal TF: Updated Portal token validity 24 hours

### DIFF
--- a/terraform/stacks/umccr_data_portal/main.tf
+++ b/terraform/stacks/umccr_data_portal/main.tf
@@ -550,6 +550,8 @@ resource "aws_cognito_user_pool_client" "user_pool_client" {
   allowed_oauth_flows_user_pool_client = true
   allowed_oauth_scopes                 = ["email", "openid", "profile", "aws.cognito.signin.user.admin"]
 
+  id_token_validity = 24
+
   # Need to explicitly specify this dependency
   depends_on = [aws_cognito_identity_provider.identity_provider]
 }


### PR DESCRIPTION
* This is the easiest way to bump token validity to
  24 hours expiration for normal use case.
  To follow up later with making use of Refresh token
  for use cases that require longer than 24 hours and/or
  service-to-service API calls.
