### PR TITLE
Slack CDK: use individual rules for Batch queues

### DIFF
--- a/cdk/apps/slack/stacks/slack_lambda.py
+++ b/cdk/apps/slack/stacks/slack_lambda.py
@@ -85,7 +85,11 @@ class BatchLambdaStack(core.Stack):
             'WtsReport':      {'name': 'wts_report_batch_queue_dev',             'enabled': True},
         }
         for job_queue_id, job_queue_config in batch_job_queues.items():
-            rule = _events.Rule(
+            aws_account_id = kwargs['env']['account']
+            aws_region = kwargs['env']['region']
+            job_queue_name = job_queue_config['name']
+            job_queue_arn = f'arn:aws:batch:{aws_region}:{aws_account_id}:job-queue/{job_queue_name}'
+            _events.Rule(
                 self,
                 f'BatchEventToSlackLambda{job_queue_id}',
                 enabled=job_queue_config['enabled'],
@@ -96,7 +100,7 @@ class BatchLambdaStack(core.Stack):
                             'SUCCEEDED',
                             'RUNNABLE',
                         ],
-                        'jobQueue': job_queue_config['name'],
+                        'jobQueue': [job_queue_arn],
                     },
                     detail_type=['Batch Job State Change'],
                     source=['aws.batch'],

--- a/cdk/apps/slack/stacks/slack_lambda.py
+++ b/cdk/apps/slack/stacks/slack_lambda.py
@@ -85,10 +85,8 @@ class BatchLambdaStack(core.Stack):
             'WtsReport':      {'name': 'wts_report_batch_queue_dev',             'enabled': True},
         }
         for job_queue_id, job_queue_config in batch_job_queues.items():
-            aws_account_id = kwargs['env']['account']
-            aws_region = kwargs['env']['region']
             job_queue_name = job_queue_config['name']
-            job_queue_arn = f'arn:aws:batch:{aws_region}:{aws_account_id}:job-queue/{job_queue_name}'
+            job_queue_arn = f'arn:aws:batch:{self.region}:{self.account}:job-queue/{job_queue_name}'
             _events.Rule(
                 self,
                 f'BatchEventToSlackLambda{job_queue_id}',

--- a/cdk/apps/slack/stacks/slack_lambda.py
+++ b/cdk/apps/slack/stacks/slack_lambda.py
@@ -77,17 +77,30 @@ class BatchLambdaStack(core.Stack):
             role=lambda_role
         )
 
-        rule = _events.Rule(
-            self,
-            'BatchEventToSlackLambda'
-        )
-        rule.add_event_pattern(
-            source=['aws.batch'],
-            detail_type=['Batch Job State Change'],
-            detail={'status': [
-                'FAILED',
-                'SUCCEEDED',
-                'RUNNABLE'
-            ]}
-        )
-        rule.add_target(_events_targets.LambdaFunction(handler=function))
+        batch_job_queues = {
+            'AGHA':           {'name': 'agha-job-queue',                         'enabled': True},
+            'Umccrise':       {'name': 'cdk-umccrise_job_queue',                 'enabled': True},
+            'UmccriseDragen': {'name': 'cdk-umccrise_job_queue-dragen-testing',  'enabled': False},
+            'Nextflow':       {'name': 'nextflow-job-queue',                     'enabled': False},
+            'WtsReport':      {'name': 'wts_report_batch_queue_dev',             'enabled': True},
+        }
+        for job_queue_id, job_queue_config in batch_job_queues.items():
+            rule = _events.Rule(
+                self,
+                f'BatchEventToSlackLambda{job_queue_id}',
+                enabled=job_queue_config['enabled'],
+                event_pattern=_events.EventPattern(
+                    detail={
+                        'status': [
+                            'FAILED',
+                            'SUCCEEDED',
+                            'RUNNABLE',
+                        ],
+                        'jobQueue': job_queue_config['name'],
+                    },
+                    detail_type=['Batch Job State Change'],
+                    source=['aws.batch'],
+                ),
+                rule_name=f'batch-slack-notifications-{job_queue_id.lower()}',
+                targets=[_events_targets.LambdaFunction(handler=function)]
+            )


### PR DESCRIPTION
Replace the catch-all CloudWatch event rule for Batch job status change
with individual rules for each Batch job queue. This allows Slack
notifications for specific job queues to be enabled or disabled.