### PR TITLE
Umccrise: make adjustments to allow non-root user in Docker container

### DIFF
--- a/cdk/apps/umccrise/assets/batch-user-data.sh
+++ b/cdk/apps/umccrise/assets/batch-user-data.sh
@@ -38,5 +38,7 @@ echo formatting and mounting disk
 # assuming the device is available under the requested name
 sudo mkfs -t xfs /dev/xvdf
 mount /dev/xvdf /mnt
+# set uid and gid of /mnt/ as the 'umccrise' user and group defined in the Umccrise Dockerfile
+chown 1000:1000 /mnt
 docker info
 echo END CUSTOM USERDATA

--- a/cdk/apps/umccrise/assets/umccrise-wrapper.sh
+++ b/cdk/apps/umccrise/assets/umccrise-wrapper.sh
@@ -76,7 +76,7 @@ mkdir -p /work/{bcbio_project,${job_output_dir},panel_of_normals,pcgr,seq,tmp,va
 # Install the AWS CLI
 curl -s "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
 unzip -qq awscliv2.zip
-./aws/install
+./aws/install --install-dir "${HOME}/.local/" --bin-dir "${HOME}/.local/bin"
 
 echo "PULL referenece data"
 # clone the refData repo making sure we are not clashing with another process

--- a/cdk/apps/umccrise/assets/umccrise-wrapper.sh
+++ b/cdk/apps/umccrise/assets/umccrise-wrapper.sh
@@ -61,10 +61,7 @@ sig_handler() {
 }
 trap sig_handler INT HUP TERM QUIT EXIT
 
-
-
 timestamp="$(date +%s)"
-instance_type="$(curl http://169.254.169.254/latest/meta-data/instance-type/)"
 
 echo "Processing $S3_INPUT_DIR in bucket $S3_DATA_BUCKET with refdata from ${S3_REFDATA_BUCKET}"
 

--- a/cdk/apps/umccrise/lambdas/umccrise/umccrise.py
+++ b/cdk/apps/umccrise/lambdas/umccrise/umccrise.py
@@ -55,8 +55,6 @@ batch_job_container_props = {
             'sourceVolume': 'container'
         }
     ],
-    'readonlyRootFilesystem': False,
-    'privileged': True,
     'ulimits': []
 }
 

--- a/cdk/apps/umccrise/stacks/batch.py
+++ b/cdk/apps/umccrise/stacks/batch.py
@@ -299,7 +299,6 @@ class BatchStack(core.Stack):
                     )
                 )
             ],
-            privileged=True
         )
 
         job_definition = batch.JobDefinition(


### PR DESCRIPTION
These changes reduce privileges granted to the Umccrise Docker container and allows execution of `umccrise-wrapper.sh` by a non-root user. Please see https://github.com/umccr/umccrise/pull/68 for changes made to the Umccrise Dockerfile and install script.