### PR TITLE
Use alternative hash table paths for production workflows

### DIFF
--- a/terraform/stacks/umccr_data_portal/workflow/main.tf
+++ b/terraform/stacks/umccr_data_portal/workflow/main.tf
@@ -153,7 +153,7 @@ locals {
       },
       "reference_tar": {
         "class": "File",
-        "location": "gds://umccr-refdata-prod/dragen/genomes/hg38/3.7.5/hg38_alt_ht_3_7_5.tar.gz"
+        "location": "gds://production/reference-data/dragen_hash_tables/v8/hg38/altaware-cnv-anchored/hg38-v8-altaware-cnv-anchored.tar.gz"
       }
     }
     EOT
@@ -196,7 +196,7 @@ locals {
         "enable_sv": true,
         "reference_tar": {
             "class": "File",
-            "location": "gds://umccr-refdata-prod/dragen/genomes/hg38/3.7.5/hg38_alt_ht_3_7_5.tar.gz"
+            "location": "gds://production/reference-data/dragen_hash_tables/v8/hg38/altaware-cnv-anchored/hg38-v8-altaware-cnv-anchored.tar.gz"
         }
     }
     EOT
@@ -271,7 +271,7 @@ locals {
       },
       "reference_tar": {
         "class": "File",
-        "location": "gds://umccr-refdata-prod/dragen/genomes/hg38/3.7.5/hg38_alt_ht_3_7_5.tar.gz"
+        "location": "gds://production/reference-data/dragen_hash_tables/v8/hg38/altaware-cnv-anchored/hg38-v8-altaware-cnv-anchored.tar.gz"
       }
     }
     EOT


### PR DESCRIPTION
## TODO
- [x] Test out #165 on dataportal
- [x] https://github.com/umccr/cwl-ica/pull/15 is pulled and a workflow version exists on prod
- [x] We launch the workflow version generated in https://github.com/umccr/cwl-ica/pull/15 with the inputs described [here](https://github.com/umccr/workflows/blob/dragen-reference-update-3.7.5/DRAGEN_README.md#reference-hash-tables), and as shown [here](https://github.com/umccr/cwl-ica/blob/main/.github/catalogue/docs/tools/custom-create-umccr-dragen-refdata-tarball-from-illumina-tar/1.0.0/custom-create-umccr-dragen-refdata-tarball-from-illumina-tar__1.0.0.md#run-wfr3bf2bc688d0d442489cadfcdb2bf9842)

## Description
Mirror of #165 but for prod workflows