### PR TITLE
Portal TF: Bump `aws/codebuild/standard:5.0`

### DIFF
--- a/terraform/stacks/umccr_data_portal/cicd.tf
+++ b/terraform/stacks/umccr_data_portal/cicd.tf
@@ -212,7 +212,7 @@ resource "aws_codebuild_project" "codebuild_client" {
 
   environment {
     compute_type = "BUILD_GENERAL1_SMALL"
-    image        = "aws/codebuild/standard:4.0"
+    image        = "aws/codebuild/standard:5.0"
     type         = "LINUX_CONTAINER"
 
     environment_variable {
@@ -291,7 +291,7 @@ resource "aws_codebuild_project" "codebuild_apis" {
 
   environment {
     compute_type    = "BUILD_GENERAL1_SMALL"
-    image           = "aws/codebuild/standard:4.0"
+    image           = "aws/codebuild/standard:5.0"
     type            = "LINUX_CONTAINER"
     privileged_mode = true
 


### PR DESCRIPTION
* Prep for next LTS: Python3.9 and Node 14
* See https://docs.aws.amazon.com/codebuild/latest/userguide/available-runtimes.html
