### PR TITLE
Updated ctTSO workflow in prod

### DIFF
--- a/terraform/stacks/umccr_data_portal/workflow/main.tf
+++ b/terraform/stacks/umccr_data_portal/workflow/main.tf
@@ -284,7 +284,7 @@ locals {
 
   dragen_tso_ctdna_wfl_version = {
     dev = "1.1.0--1.0.0"
-    prod = "1.1.0--1.0.0--87cab58"
+    prod = "1.1.0--1.0.0--570feb0"
   }
 
   dragen_tso_ctdna_wfl_input = {


### PR DESCRIPTION
See changes : https://github.com/umccr/cwl-ica/pull/36

Summary - two additional intermediates files are put into the output directory 
* `SampleSheet_Intermediate.csv` (useful for adding SampleSheet.csv to PierianDx s3 bucket)
* `Fusions.csv`  (unintentionally omitted the first time the Results folder was built)