### PR TITLE
umccrise: minor stack updates for new release

### DIFF
--- a/cdk/apps/umccrise/assets/umccrise-wrapper.sh
+++ b/cdk/apps/umccrise/assets/umccrise-wrapper.sh
@@ -76,7 +76,12 @@ mkdir -p /work/{bcbio_project,${job_output_dir},panel_of_normals,pcgr,seq,tmp,va
 # Install the AWS CLI
 curl -s "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
 unzip -qq awscliv2.zip
-./aws/install --install-dir "${HOME}/.local/" --bin-dir "${HOME}/.local/bin"
+# Executing user in umccrise <=1.2.3 is root and has no home directory, so install AWS CLI into system directory
+if [[ ${EUID} -ne 0 ]]; then
+  ./aws/install --install-dir "${HOME}/.local/" --bin-dir "${HOME}/.local/bin"
+else
+  ./aws/install
+fi
 
 echo "PULL referenece data"
 # clone the refData repo making sure we are not clashing with another process

--- a/cdk/apps/umccrise/lambdas/slack/notify_slack.py
+++ b/cdk/apps/umccrise/lambdas/slack/notify_slack.py
@@ -156,7 +156,7 @@ def slack_message_from_codebuild(message):
                     "short": True
                 }
             ],
-            "footer": "IAP TES Task",
+            "footer": "CodeBuild Run",
             "ts": int(message_time.timestamp())
         }
     ]

--- a/cdk/apps/umccrise/umccrise-batch-params-dev.json
+++ b/cdk/apps/umccrise/umccrise-batch-params-dev.json
@@ -2,7 +2,7 @@
     "Account": "843407916570",
     "Parameters":{
         "/cdk/umccrise/batch/ami": {
-            "Value": "ami-00e4b147599c13588",
+            "Value": "ami-09fb62624e1ab3e2c",
             "Type": "String"
         },
         "/cdk/umccrise/batch/compute_env_type": {

--- a/cdk/apps/umccrise/umccrise-batch-params-prod.json
+++ b/cdk/apps/umccrise/umccrise-batch-params-prod.json
@@ -2,7 +2,7 @@
     "Account": "472057503814",
     "Parameters":{
         "/cdk/umccrise/batch/ami": {
-            "Value": "ami-00e4b147599c13588",
+            "Value": "ami-09fb62624e1ab3e2c",
             "Type": "String"
         },
         "/cdk/umccrise/batch/compute_env_type": {


### PR DESCRIPTION
Minor updates for the new umccrise release:
* run instances with a new AMI that contains a Docker version compatible with images built from Ubuntu 21.04
* install aws-cli into `/usr/local/` when Docker container runs with root user (umccrise ≤1.2.3) otherwise install into `${HOME}/.local/`
* update Slack message footer for CodeBuild status changes