### PR TITLE
Updated bclconvert workflow

### DIFF
--- a/terraform/stacks/umccr_data_portal/workflow/main.tf
+++ b/terraform/stacks/umccr_data_portal/workflow/main.tf
@@ -62,7 +62,7 @@ locals {
 
   bcl_convert_wfl_version = {
     dev  = "3.7.5"
-    prod = "3.7.5--f1e67a3"
+    prod = "3.7.5--fade666"
   }
 
   bcl_convert_wfl_input = {


### PR DESCRIPTION
* Override cycles matching '\w+;\w+;[nN]\d+;[nN]\d+' now auto-removes adapterread2 from samplesheet settings

---

- [ ] @victorskl to follow up apply to PROD when closing Korat milestone.