### PR TITLE
Updated somalier and reference file

### DIFF
--- a/terraform/stacks/umccr_data_portal/workflow/main.tf
+++ b/terraform/stacks/umccr_data_portal/workflow/main.tf
@@ -126,11 +126,11 @@ locals {
       "fastq_list_rows": null,
       "sites_somalier": {
         "class": "File",
-        "location": "gds://umccr-refdata-dev/somalier/sites.hg38.vcf.gz"
+        "location": "gds://development/reference-data/somalier/sites.hg38.rna.vcf.gz"
       },
       "reference_fasta": {
         "class": "File",
-        "location": "gds://umccr-refdata-dev/dragen/genomes/hg38/hg38.fa"
+        "location": "gds://development/reference-data/genomes/hg38/hg38.fa"
       },
       "reference_tar": {
         "class": "File",
@@ -145,11 +145,11 @@ locals {
       "fastq_list_rows": null,
       "sites_somalier": {
         "class": "File",
-        "location": "gds://umccr-refdata-prod/somalier/sites.hg38.vcf.gz"
+        "location": "gds://production/reference-data/somalier/sites.hg38.rna.vcf.gz"
       },
       "reference_fasta": {
         "class": "File",
-        "location": "gds://umccr-refdata-prod/dragen/genomes/hg38/hg38.fa"
+        "location": "gds://production/reference-data/genomes/hg38/hg38.fa"
       },
       "reference_tar": {
         "class": "File",


### PR DESCRIPTION
## Updates

* Change somalier file for alignment qc workflow to rna file 
* Change reference data to fasta in root volume

* gds volumes umccr-refdata-dev and umccr-refdata-prod are no longer used for automated workflows

## TODO 
- [x] Compare md5sum of reference fasta files (items in umccr-refdata-x do NOT have an eTag)
  * Both md5sums are evaluated to `64b32de2fc934679c16e83a2bc072064`
