### PR TITLE
Pin Umccrise reference data version to 1.0.11

### DIFF
--- a/cdk/apps/umccrise/assets/umccrise-wrapper.sh
+++ b/cdk/apps/umccrise/assets/umccrise-wrapper.sh
@@ -89,7 +89,7 @@ while [ -d "$REFDATA_DIR" ]; do
   echo "Refdata dir already exists. Creating new one..."
   REFDATA_DIR="${REFDATA_DIR}_1"
 done
-git clone https://github.com/umccr/reference_data $REFDATA_DIR
+git clone -b 1.0.11 https://github.com/umccr/reference_data $REFDATA_DIR
 cd $REFDATA_DIR
 
 # use a common cache dir for all DVC repos/processes


### PR DESCRIPTION
* the DVC pull command for Umccrise reference data operates on the .dvc file at HEAD on master
* upcoming changes to Umccrise reference data may impact the ability to run Umccrise 2.0.1
* this change pins Umccrise reference data pulled by DVC to 1.0.11