### PR TITLE
Update Umccrise ICA CWL workflow to 2.0.2--3.9.3

### DIFF
--- a/terraform/stacks/umccr_data_portal/workflow/main.tf
+++ b/terraform/stacks/umccr_data_portal/workflow/main.tf
@@ -390,8 +390,8 @@ locals {
   }
 
   umccrise_wfl_version = {
-    dev = "2.0.1--3.9.3"
-    prod = "2.0.1--3.9.3--a75eb35"
+    dev = "2.0.2--3.9.3"
+    prod = "2.0.2--3.9.3--0a80def"
   }
 
   umccrise_wfl_input = {


### PR DESCRIPTION
* successfully completed run set in dev on existing `SBJ01307` DRAGEN data
* above run generated identical outputs to the previous Umccrise run for the sample
* workflow run identifiers:
  * `wfr.c50dd7661fee4571946e8444eca3345c` (Umccrise with DRAGEN germline)
  * `wfr.a29f3fe85ad7437e9b490cf49a7eea4f` (Umccrise only)
