### PR TITLE
Updated production workflow of tso_ctdna

### DIFF
--- a/terraform/stacks/umccr_data_portal/workflow/main.tf
+++ b/terraform/stacks/umccr_data_portal/workflow/main.tf
@@ -338,7 +338,7 @@ locals {
 
   tso_ctdna_tumor_only_wfl_version = {
     dev = "1.1.0--1.0.0"
-    prod = "1.1.0--1.0.0--b8f38b3"
+    prod = "1.1.0--1.0.0--d7621f6"
   }
 
   tso_ctdna_tumor_only_wfl_input = {


### PR DESCRIPTION
## Changes

* Include multiqc step for AlignCollapseFusionCaller step
* Fail earlier in case of workflow step failing by examining dsdm jsons at the end of the initial subworkflow
* Coerce correct index for samples with 'invalid' but technically compatible fastq indexes