### PR TITLE
Portal TF: Reverted CodeBuild image to Standard 5.0

### DIFF
--- a/terraform/stacks/umccr_data_portal/cicd.tf
+++ b/terraform/stacks/umccr_data_portal/cicd.tf
@@ -252,7 +252,7 @@ resource "aws_codebuild_project" "codebuild_client" {
 
   environment {
     compute_type = "BUILD_GENERAL1_SMALL"
-    image        = "aws/codebuild/standard:6.0"
+    image        = "aws/codebuild/standard:5.0"
     type         = "LINUX_CONTAINER"
 
     environment_variable {
@@ -346,7 +346,7 @@ resource "aws_codebuild_project" "codebuild_apis" {
 
   environment {
     compute_type    = "BUILD_GENERAL1_SMALL"
-    image           = "aws/codebuild/standard:6.0"
+    image           = "aws/codebuild/standard:5.0"
     type            = "LINUX_CONTAINER"
     privileged_mode = true
 


### PR DESCRIPTION
* Mainly due to backend Lambda runtime limitation i.e.
  CodeBuild `Ubuntu Standard:6.0` image supports Python 3.10 Only
  Whilst Lambda runtime support is still at Python 3.9

Related #259
