### PR TITLE
GPL CI/CD URL Removal

### DIFF
--- a/terraform/stacks/umccr_data_portal/.terraform.lock.hcl
+++ b/terraform/stacks/umccr_data_portal/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   version     = "4.38.0"
   constraints = "4.38.0"
   hashes = [
+    "h1:I5nw2H5JHYib6mrikp8aJl2pbEQVJrgMVU488PHZWb8=",
     "h1:LympybKZJE3L0H12nMmDnFH1iexD9S2GqZbDMo4fuPI=",
     "zh:0ae61458acf7acecf47f7a02e08da1f7adeee9532e053c0d80432f16197e4799",
     "zh:1ece9bcef41ffc75e0955419d7f8b1708ab7ffe4518bc9a2afe3bc5c79a9e79b",

--- a/terraform/stacks/umccr_data_portal/cicd.tf
+++ b/terraform/stacks/umccr_data_portal/cicd.tf
@@ -45,21 +45,6 @@ data "aws_ssm_parameter" "htsget_domain" {
   name = "/htsget/domain"
 }
 
-data "aws_ssm_parameter" "gpl_submit_job" {
-  name = "/gpl/submit_job_lambda_fn_url"
-}
-
-data "aws_ssm_parameter" "gpl_submit_job_manual" {
-  name = "/gpl/submit_job_manual_lambda_fn_url"
-}
-
-# As of GPL v0.2.0, Do not deploy LINX plotting Lambda
-# See https://github.com/umccr/gridss-purple-linx-nf/commit/a015146e95e1b7cd3de3bc639cbc600887ba42ff
-# FIXME If re-enable, also uncomment env var in client CodeBuild -- search GPL_CREATE_LINX_PLOT
-#data "aws_ssm_parameter" "gpl_create_linx_plot" {
-#  name = "/gpl/create_linx_plot_lambda_fn_url"
-#}
-
 # Bucket storing codepipeline artifacts (both client and apis)
 resource "aws_s3_bucket" "codepipeline_bucket" {
   bucket = "${local.org_name}-${local.stack_name_dash}-build-${terraform.workspace}"
@@ -296,21 +281,6 @@ resource "aws_codebuild_project" "codebuild_client" {
       name  = "HTSGET_URL"
       value = data.aws_ssm_parameter.htsget_domain.value
     }
-
-    environment_variable {
-      name  = "GPL_SUBMIT_JOB"
-      value = data.aws_ssm_parameter.gpl_submit_job.value
-    }
-
-    environment_variable {
-      name  = "GPL_SUBMIT_JOB_MANUAL"
-      value = data.aws_ssm_parameter.gpl_submit_job_manual.value
-    }
-
-    #    environment_variable {
-    #      name  = "GPL_CREATE_LINX_PLOT"
-    #      value = data.aws_ssm_parameter.gpl_create_linx_plot.value
-    #    }
 
     environment_variable {
       name  = "REGION"

--- a/terraform/stacks/umccr_data_portal/data2.tf
+++ b/terraform/stacks/umccr_data_portal/data2.tf
@@ -291,21 +291,6 @@ resource "aws_codebuild_project" "codebuild_data2" {
     }
 
     environment_variable {
-      name  = "GPL_SUBMIT_JOB"
-      value = data.aws_ssm_parameter.gpl_submit_job.value
-    }
-
-    environment_variable {
-      name  = "GPL_SUBMIT_JOB_MANUAL"
-      value = data.aws_ssm_parameter.gpl_submit_job_manual.value
-    }
-
-    #    environment_variable {
-    #      name  = "GPL_CREATE_LINX_PLOT"
-    #      value = data.aws_ssm_parameter.gpl_create_linx_plot.value
-    #    }
-
-    environment_variable {
       name  = "REGION"
       value = data.aws_region.current.name
     }


### PR DESCRIPTION
GPL FuncUrl no longer needed at the portal and will call lambda invoke instead. (https://github.com/umccr/data-portal-client/issues/235)

Ref: https://github.com/umccr/data-portal-client/pull/237#pullrequestreview-1322967240