### PR TITLE
Update production tumor normal workflow id and version to also run germline tool

### DIFF
--- a/terraform/stacks/umccr_data_portal/workflow/template/wgs_tumor_normal_prod.json
+++ b/terraform/stacks/umccr_data_portal/workflow/template/wgs_tumor_normal_prod.json
@@ -1,6 +1,8 @@
 {
-  "output_file_prefix": null,
-  "output_directory": null,
+  "output_file_prefix_germline": null,
+  "output_file_prefix_somatic": null,
+  "output_directory_germline": null,
+  "output_directory_somatic": null,
   "fastq_list_rows": [],
   "tumor_fastq_list_rows": [],
   "enable_map_align_output": true,

--- a/terraform/stacks/umccr_data_portal/workflow/wgs_tumor_normal.tf
+++ b/terraform/stacks/umccr_data_portal/workflow/wgs_tumor_normal.tf
@@ -1,13 +1,13 @@
 locals {
   wgs_tumor_normal_wfl_id = {
     dev  = "wfl.a4056543ef9a474d8b16182a4e6b6c50"
-    prod = "wfl.aa0ccece4e004839aa7374d1d6530633"
+    prod = "wfl.5830565f0858423cb49de2a1534d65c5"
     stg  = "wfl.5830565f0858423cb49de2a1534d65c5"
   }
 
   wgs_tumor_normal_wfl_version = {
     dev  = "3.9.3"
-    prod = "3.9.3--4e00721"
+    prod = "3.9.3--e4acc1a"
     stg  = "3.9.3--e4acc1a"
   }
 


### PR DESCRIPTION
Now run germline and somatic simultaneously
* Updated input template to add germline prefixes and directories
* Updated to new workflow and workflow version for production.

* Related PRS
	* https://github.com/umccr/infrastructure/pull/287
	* https://github.com/umccr/infrastructure/pull/284

