### PR TITLE
No longer run germline with umccrise, instead germline is run with somatic

### DIFF
--- a/terraform/stacks/umccr_data_portal/workflow/template/umccrise_prod.json
+++ b/terraform/stacks/umccr_data_portal/workflow/template/umccrise_prod.json
@@ -1,17 +1,12 @@
 {
+  "dragen_normal_id": null,
+  "dragen_tumor_id": null,
   "dragen_somatic_directory": null,
-  "fastq_list_rows_germline": null,
-  "output_directory_germline": null,
-  "output_directory_umccrise": null,
-  "output_file_prefix_germline": null,
-  "enable_duplicate_marking": true,
-  "reference_tar_germline": {
-    "class": "File",
-    "location": "gds://production/reference-data/dragen_hash_tables/v8/hg38/altaware-cnv-anchored/hg38-v8-altaware-cnv-anchored.tar.gz"
-  },
-  "reference_tar_umccrise": {
+  "dragen_germline_directory": null,
+  "output_directory_name": null,
+  "genomes_tar": {
     "class": "File",
     "location": "gds://production/reference-data/umccrise/1.0.10/genomes.tar.gz"
   },
-  "subject_identifier_umccrise": null
+  "subject_identifier": null
 }

--- a/terraform/stacks/umccr_data_portal/workflow/umccrise.tf
+++ b/terraform/stacks/umccr_data_portal/workflow/umccrise.tf
@@ -1,13 +1,13 @@
 locals {
   umccrise_wfl_id = {
     dev  = "wfl.af61d2b172e84cbfa85eaf184226db8b"
-    prod = "wfl.7ed9c6014ac9498fbcbd4c17c28bc0d4"
+    prod = "wfl.714e9172f3674023b210ccc7c47db05a"
     stg  = "wfl.714e9172f3674023b210ccc7c47db05a"
   }
 
   umccrise_wfl_version = {
     dev  = "2.2.0--0"
-    prod = "2.2.0--3.9.3--4e00721"
+    prod = "2.2.0--0--052b3fa"
     stg  = "2.2.0--0--052b3fa"
   }
 


### PR DESCRIPTION
* Now just runs the umccrise tool instead.

* Related PRs
	* https://github.com/umccr/infrastructure/pull/284
	* https://github.com/umccr/infrastructure/pull/288