### PR TITLE
Update RNASum workflow version to use more appropriate resources

### DIFF
--- a/terraform/stacks/umccr_data_portal/workflow/rnasum.tf
+++ b/terraform/stacks/umccr_data_portal/workflow/rnasum.tf
@@ -7,7 +7,7 @@ locals {
 
   rnasum_wfl_version = {
     dev  = "0.4.5"
-    prod = "0.4.5--c801102"
+    prod = "0.4.5--d4e20ab"
     stg  = "0.4.5--d4e20ab"
   }
 


### PR DESCRIPTION
Update rnasum tool to use standard xxlarge over standard hicpu large instance.

Related commentary / PRs

* https://github.com/umccr/cwl-ica/issues/238
* https://github.com/umccr/cwl-ica/pull/242
* https://github.com/umccr/cwl-ica/issues/298
* https://github.com/umccr/cwl-ica/pull/299
* https://github.com/umccr-illumina/ica_v2/issues/128
* https://github.com/umccr/infrastructure/pull/289