### PR TITLE
Update bastion ecr permissions for oncoanalyser repo

### DIFF
--- a/terraform/stacks/bastion_ecr/main.tf
+++ b/terraform/stacks/bastion_ecr/main.tf
@@ -66,7 +66,7 @@ resource "aws_ecr_lifecycle_policy" "cttso_ica_to_pieriandx_lifecycle" {
 #
 
 resource "aws_ecr_repository" "oncoanalyser" {
-  name                 = "cttso-ica-to-pieriandx"
+  name                 = "oncoanalyser"
   image_tag_mutability = "MUTABLE"
   image_scanning_configuration {
     scan_on_push = false

--- a/terraform/stacks/bastion_ecr/main.tf
+++ b/terraform/stacks/bastion_ecr/main.tf
@@ -59,3 +59,27 @@ resource "aws_ecr_lifecycle_policy" "cttso_ica_to_pieriandx_lifecycle" {
   repository = aws_ecr_repository.cttso_ica_to_pieriandx.name
   policy     = templatefile("policies/untagged_image_policy.json", {})
 }
+
+
+####
+# oncoanalyser
+#
+
+resource "aws_ecr_repository" "oncoanalyser" {
+  name                 = "cttso-ica-to-pieriandx"
+  image_tag_mutability = "MUTABLE"
+  image_scanning_configuration {
+    scan_on_push = false
+  }
+}
+
+resource "aws_ecr_repository_policy" "oncoanalyser_cross_accounts" {
+  repository = aws_ecr_repository.oncoanalyser.name
+  policy     = templatefile("policies/cross_accounts_policy_umccr.json", {})
+}
+
+# Policy on untagged image
+resource "aws_ecr_lifecycle_policy" "oncoanalyser_lifecycle" {
+  repository = aws_ecr_repository.oncoanalyser.name
+  policy     = templatefile("policies/untagged_image_policy.json", {})
+}


### PR DESCRIPTION
Copied policies used for the cttso-ica-to-pieriandx tf stack above

Allows images in the bastion ecr repository 'oncoanalyser' to be accessed from staging and production