### PR TITLE
Updated staging workflow versions and template for tn and umccrise

### DIFF
--- a/terraform/stacks/umccr_data_portal/workflow/template/wgs_tumor_normal_stg.json
+++ b/terraform/stacks/umccr_data_portal/workflow/template/wgs_tumor_normal_stg.json
@@ -6,8 +6,10 @@
   "fastq_list_rows": [],
   "tumor_fastq_list_rows": [],
   "enable_map_align_output": true,
+  "enable_map_align_output_germline": false,
   "enable_duplicate_marking": true,
   "enable_sv": true,
+  "enable_sv_germline": false,
   "reference_tar": {
     "class": "File",
     "location": "gds://staging/reference-data/dragen_hash_tables/v8/hg38/altaware-cnv-anchored/hg38-v8-altaware-cnv-anchored.tar.gz"

--- a/terraform/stacks/umccr_data_portal/workflow/umccrise.tf
+++ b/terraform/stacks/umccr_data_portal/workflow/umccrise.tf
@@ -8,7 +8,7 @@ locals {
   umccrise_wfl_version = {
     dev  = "2.2.0--0"
     prod = "2.2.0--0--052b3fa"
-    stg  = "2.2.0--0--052b3fa"
+    stg  = "2.2.0--0--3fc7b5e"
   }
 
   umccrise_wfl_input = {

--- a/terraform/stacks/umccr_data_portal/workflow/wgs_tumor_normal.tf
+++ b/terraform/stacks/umccr_data_portal/workflow/wgs_tumor_normal.tf
@@ -8,7 +8,7 @@ locals {
   wgs_tumor_normal_wfl_version = {
     dev  = "3.9.3"
     prod = "3.9.3--e4acc1a"
-    stg  = "3.9.3--e4acc1a"
+    stg  = "3.9.3--ae21995"
   }
 
   wgs_tumor_normal_wfl_input = {


### PR DESCRIPTION
Upgraded versions of tn pipeline and umccrise tool to allow for bam to not be generated in germline directory.  

This requires a umccrise version upgrade to copy over the normal bam to the umccrise directory first.