### PR TITLE
Updated prod workflow versions and template for tn and umccrise

### DIFF
--- a/terraform/stacks/umccr_data_portal/workflow/template/wgs_tumor_normal_prod.json
+++ b/terraform/stacks/umccr_data_portal/workflow/template/wgs_tumor_normal_prod.json
@@ -5,9 +5,10 @@
   "output_directory_somatic": null,
   "fastq_list_rows": [],
   "tumor_fastq_list_rows": [],
-  "enable_map_align_output": true,
+  "enable_map_align_output_germline": false,
   "enable_duplicate_marking": true,
   "enable_sv": true,
+  "enable_sv_germline": false,
   "reference_tar": {
     "class": "File",
     "location": "gds://production/reference-data/dragen_hash_tables/v8/hg38/altaware-cnv-anchored/hg38-v8-altaware-cnv-anchored.tar.gz"

--- a/terraform/stacks/umccr_data_portal/workflow/umccrise.tf
+++ b/terraform/stacks/umccr_data_portal/workflow/umccrise.tf
@@ -7,7 +7,7 @@ locals {
 
   umccrise_wfl_version = {
     dev  = "2.2.0--0"
-    prod = "2.2.0--0--052b3fa"
+    prod = "2.2.0--0--3fc7b5e"
     stg  = "2.2.0--0--3fc7b5e"
   }
 

--- a/terraform/stacks/umccr_data_portal/workflow/wgs_tumor_normal.tf
+++ b/terraform/stacks/umccr_data_portal/workflow/wgs_tumor_normal.tf
@@ -7,7 +7,7 @@ locals {
 
   wgs_tumor_normal_wfl_version = {
     dev  = "3.9.3"
-    prod = "3.9.3--e4acc1a"
+    prod = "3.9.3--ae21995"
     stg  = "3.9.3--ae21995"
   }
 


### PR DESCRIPTION
Upgraded versions to allow for bam to not be generated in germline directory.    

This requires a umccrise upgrade to copy over the normal bam to the umccrise directory first.

We also update the tn template to not generate the germline bam AND to also not run the sv caller (which requires the map align output to be present).