### PR TITLE
HOTFIX: TF data archive - Update oncoanalyser bucket lifecycle

### DIFF
--- a/terraform/stacks/data_archive/oncoanalyser.tf
+++ b/terraform/stacks/data_archive/oncoanalyser.tf
@@ -87,10 +87,12 @@ resource "aws_s3_bucket_lifecycle_configuration" "oncoanalyser_bucket" {
 		prefix = "temp_data/"
 	}
 
-    transition {
-      days          = 0
-      storage_class = "ONEZONE_IA"
-    }
+	# ONEZONE_IA requires min 30, so unless the expiration time
+	# is increased, this is not needed
+    # transition {
+    #   days          = 30
+    #   storage_class = "ONEZONE_IA"
+    # }
 
 	expiration {
       days = 30


### PR DESCRIPTION
Remove ONEZONE_IA transition as it requires min 30 days, which is the current expiration time