### PR TITLE
Update Batch Slack notifier queue selection

### DIFF
--- a/cdk/apps/slack/stacks/slack_lambda.py
+++ b/cdk/apps/slack/stacks/slack_lambda.py
@@ -77,18 +77,14 @@ class BatchLambdaStack(core.Stack):
             role=lambda_role
         )
 
-        job_queue_eb_prefixes = [
-            'cdk-umccrise_job_queue',
-            'cttso-ica-to-pieriandx-',
-            'gpl-job-queue',
-            'nextflow-pipeline-ondemand',
-            'wts_report_batch_queue_',
+        job_queue_exclude_eb_prefixes = [
+            'nextflow-task-',
         ]
 
-        job_queue_eb_patterns = list()
-        for job_queue_eb_prefix in job_queue_eb_prefixes:
-            pattern = f'arn:aws:batch:{self.region}:{self.account}:job-queue/{job_queue_eb_prefix}'
-            job_queue_eb_patterns.append(pattern)
+        job_queue_exclude_eb_patterns = list()
+        for prefix in job_queue_exclude_eb_prefixes:
+            pattern = f'arn:aws:batch:{self.region}:{self.account}:job-queue/{prefix}'
+            job_queue_exclude_eb_patterns.append(pattern)
 
         _events.Rule(
             self,
@@ -100,7 +96,7 @@ class BatchLambdaStack(core.Stack):
                         'SUCCEEDED',
                         'RUNNABLE',
                     ],
-                    'jobQueue': [{'prefix': s} for s in job_queue_eb_patterns],
+                    'jobQueue': [{'anything-but': {'prefix': s}} for s in job_queue_exclude_eb_patterns],
                 },
                 detail_type=['Batch Job State Change'],
                 source=['aws.batch'],


### PR DESCRIPTION
**Background**

* prod currently has a Batch job Slack notifier that captures all job changes (see [here](https://github.com/umccr/infrastructure/blob/cb80fd0f7096b8e76e932d592d4b48d91e020832/cdk/apps/slack/stacks/slack_lambda.py#L80-L93))
* until now all workflows have used a single job for execution but Nextflow uses one job per task
* hence the notifier must be selective to avoid spamming corresponding Slack channels
* I've proposed to ignore all Nextflow task jobs and only report Nextflow pipeline jobs
* some work has previously been done to use [queue selection](https://github.com/umccr/infrastructure/blob/3427e3130ff8baf754cb74f8c4cd1abc4af7e1fb/cdk/apps/slack/stacks/slack_lambda.py#L80-L108) (deployed only in dev)

Relevant Slack thread: https://umccr.slack.com/archives/C05784MU2F5/p1684966054480459

**Changes**

* merged multiple event rules back into single event rule
* allow notification from all queues _except_ Nextflow task queues (`nextflow-task-*`)

_These changes intended to serve as a short term fix rather than a long term solution_

**Tests**

* deployed to dev
* ran example job in each target queue + observed notification in Slack
* ran Nextflow _task_ job on task queue + did not observe notification in Slack