### PR TITLE
Update rnasum dev verison to 0.4.7

### DIFF
--- a/terraform/stacks/umccr_data_portal/workflow/rnasum.tf
+++ b/terraform/stacks/umccr_data_portal/workflow/rnasum.tf
@@ -6,7 +6,7 @@ locals {
   }
 
   rnasum_wfl_version = {
-    dev  = "0.4.5"
+    dev  = "0.4.7"
     prod = "0.4.5--d4e20ab"
     stg  = "0.4.5--d4e20ab"
   }


### PR DESCRIPTION
- cwl-ica PR https://github.com/umccr/cwl-ica/pull/350
- rnasum-0.4.7 will be back ported to Snowshoe