### PR TITLE
Update rnasum prod verison to 0.4.7

### DIFF
--- a/terraform/stacks/umccr_data_portal/workflow/rnasum.tf
+++ b/terraform/stacks/umccr_data_portal/workflow/rnasum.tf
@@ -7,7 +7,7 @@ locals {
 
   rnasum_wfl_version = {
     dev  = "0.4.7"
-    prod = "0.4.5--d4e20ab"
+    prod = "0.4.7--0758c9e"
     stg  = "0.4.7--0758c9e"
   }
 


### PR DESCRIPTION
- cwl-ica PR https://github.com/umccr/cwl-ica/pull/352
- rnasum-0.4.7 will be back ported to Snowshoe