### PR TITLE
Update rnasum stg verison to 0.4.7

### DIFF
--- a/terraform/stacks/umccr_data_portal/workflow/rnasum.tf
+++ b/terraform/stacks/umccr_data_portal/workflow/rnasum.tf
@@ -8,7 +8,7 @@ locals {
   rnasum_wfl_version = {
     dev  = "0.4.5"
     prod = "0.4.5--d4e20ab"
-    stg  = "0.4.5--d4e20ab"
+    stg  = "0.4.7--0758c9e"
   }
 
   rnasum_wfl_input = {


### PR DESCRIPTION
- cwl-ica PR https://github.com/umccr/cwl-ica/pull/352
- rnasum-0.4.7 will be back ported to Snowshoe