### PR TITLE
Restrict Deep Archive transition

### DIFF
--- a/terraform/stacks/data_archive/main.tf
+++ b/terraform/stacks/data_archive/main.tf
@@ -13,16 +13,21 @@ terraform {
 ################################################################################
 # Generic resources
 
+# Configure the AWS Provider
 provider "aws" {
-  # AWS access credentials are retrieved from env variables
-  region = "ap-southeast-2"
+  region = local.region
 }
+provider "awscc" {
+  region = local.region
+}
+
 
 data "aws_caller_identity" "current" {}
 
 data "aws_region" "current" {}
 
 locals {
+  region = "ap-southeast-2"
   stack_name = "data_archive"
 
   default_tags = {

--- a/terraform/stacks/data_archive/raw_data_archive.tf
+++ b/terraform/stacks/data_archive/raw_data_archive.tf
@@ -57,6 +57,10 @@ resource "aws_s3_bucket_lifecycle_configuration" "raw_data_bucket" {
       storage_class = "DEEP_ARCHIVE"
     }
 
+    filter {
+      object_size_greater_than = 500000
+    }
+
     # Versioning configuration
     expiration {
       expired_object_delete_marker = true


### PR DESCRIPTION
Add filter to S3 lifecycle rule to apply Deep Archive transition to only objects larger than 500KB