### PR TITLE
Upgraded tso ctdna workflow run template to version 1.2 (dev)

### DIFF
--- a/terraform/stacks/umccr_data_portal/workflow/template/tso_ctdna_tumor_only_dev.json
+++ b/terraform/stacks/umccr_data_portal/workflow/template/tso_ctdna_tumor_only_dev.json
@@ -1,11 +1,10 @@
 {
   "tso500_samples": null,
-  "fastq_list_rows": null,
   "samplesheet_prefix": "BCLConvert",
   "samplesheet": null,
   "resources_dir": {
     "class": "Directory",
-    "location": "gds://development/reference-data/dragen_tso_ctdna/ruo-1.1.0.3/"
+    "location": "gds://development/reference-data/dragen_tso_ctdna/ruo-1.2.0.4/"
   },
   "dragen_license_key": {
     "class": "File",

--- a/terraform/stacks/umccr_data_portal/workflow/tso_ctdna_tumor_only.tf
+++ b/terraform/stacks/umccr_data_portal/workflow/tso_ctdna_tumor_only.tf
@@ -6,7 +6,7 @@ locals {
   }
 
   tso_ctdna_tumor_only_wfl_version = {
-    dev  = "1.1.0--1.0.0"
+    dev  = "1.2.0--1.0.0"
     prod = "1.1.0--1.0.0--d7621f6"
     stg  = "1.1.0--1.0.0--d7621f6"
   }


### PR DESCRIPTION
* Dropped fastq_list_rows from input template (now inside tso500_samples)
* Updated resources directory location to ruo-1.2.0.4
* Upgraded dev CWL workflow version from 1.1.0 to 1.2.0