### PR TITLE
Updated wgs alignment qc to use version 4.2.4 (prod)

### DIFF
--- a/terraform/stacks/umccr_data_portal/workflow/template/wgs_alignment_qc_prod.json
+++ b/terraform/stacks/umccr_data_portal/workflow/template/wgs_alignment_qc_prod.json
@@ -7,6 +7,13 @@
   "enable_sort": true,
   "reference_tar": {
     "class": "File",
-    "location": "gds://production/reference-data/dragen_hash_tables/v8/hg38/altaware-cnv-anchored/hg38-v8-altaware-cnv-anchored.tar.gz"
+    "location": "gds://production/reference-data/dragen_hash_tables/v9-r3/hg38-alt_masked-cnv-hla-rna/hg38-alt_masked.cnv.hla.rna-9-r3.0-1.tar.gz"
+  },
+  "enable_rna": false,
+  "enable_rna_quantification": false,
+  "enable_rrna_filter": false,
+  "annotation_file": {
+    "class": "File",
+    "location": "gds://production/reference-data/dragen_wts/hg38/gencode.v39.annotation.gtf"
   }
 }

--- a/terraform/stacks/umccr_data_portal/workflow/wgs_alignment_qc.tf
+++ b/terraform/stacks/umccr_data_portal/workflow/wgs_alignment_qc.tf
@@ -1,13 +1,13 @@
 locals {
   wgs_alignment_qc_wfl_id = {
     dev  = "wfl.a3e19e590ed34a0fa0518718cb8a36cf"
-    prod = "wfl.23f61cb1baab412a8c37dc93bed6c2af"
+    prod = "wfl.c07ecc424a5a41bd94abe9ef519867a0"
     stg  = "wfl.c07ecc424a5a41bd94abe9ef519867a0"
   }
 
   wgs_alignment_qc_wfl_version = {
     dev  = "4.2.4"
-    prod = "3.9.3--4e00721"
+    prod = "4.2.4--5bfabd0"
     stg  = "4.2.4--5bfabd0"
   }
 


### PR DESCRIPTION
Updated pipeline ID (from wgs qc to alignment pipeline and version from 3.9.3 to 4.2.4)

Allow for WTS QC to use this template