### PR TITLE
Add sash ECR repo in Bastion and allow across account access

### DIFF
--- a/terraform/stacks/bastion_ecr/main.tf
+++ b/terraform/stacks/bastion_ecr/main.tf
@@ -102,6 +102,24 @@ resource "aws_ecr_repository_policy" "star_align_nf_cross_accounts" {
   policy     = templatefile("policies/cross_accounts_policy_umccr.json", {})
 }
 
+
+####
+# sash
+#
+
+resource "aws_ecr_repository" "sash" {
+  name                 = "sash"
+  image_tag_mutability = "MUTABLE"
+  image_scanning_configuration {
+    scan_on_push = false
+  }
+}
+
+resource "aws_ecr_repository_policy" "sash_cross_accounts" {
+  repository = aws_ecr_repository.sash.name
+  policy     = templatefile("policies/cross_accounts_policy_umccr.json", {})
+}
+
 # Policy on untagged image
 resource "aws_ecr_lifecycle_policy" "star_align_nf_lifecycle" {
   repository = aws_ecr_repository.star_align_nf.name

--- a/terraform/stacks/bastion_ecr/main.tf
+++ b/terraform/stacks/bastion_ecr/main.tf
@@ -102,6 +102,12 @@ resource "aws_ecr_repository_policy" "star_align_nf_cross_accounts" {
   policy     = templatefile("policies/cross_accounts_policy_umccr.json", {})
 }
 
+# Policy on untagged image
+resource "aws_ecr_lifecycle_policy" "star_align_nf_lifecycle" {
+  repository = aws_ecr_repository.star_align_nf.name
+  policy     = templatefile("policies/untagged_image_policy.json", {})
+}
+
 
 ####
 # sash
@@ -121,7 +127,7 @@ resource "aws_ecr_repository_policy" "sash_cross_accounts" {
 }
 
 # Policy on untagged image
-resource "aws_ecr_lifecycle_policy" "star_align_nf_lifecycle" {
-  repository = aws_ecr_repository.star_align_nf.name
+resource "aws_ecr_lifecycle_policy" "sash_lifecycle" {
+  repository = aws_ecr_repository.sash.name
   policy     = templatefile("policies/untagged_image_policy.json", {})
 }


### PR DESCRIPTION
Change overview:

* adds an ECR repo for sash in the Bastion account
* attaches existing policy for across account sharing/access

Also see:

* https://github.com/umccr/infrastructure/pull/299/
* https://github.com/umccr/infrastructure/pull/307