### PR TITLE
umccrise: update stg to 2.3.1--1

### DIFF
--- a/terraform/stacks/umccr_data_portal/workflow/umccrise.tf
+++ b/terraform/stacks/umccr_data_portal/workflow/umccrise.tf
@@ -8,7 +8,7 @@ locals {
   umccrise_wfl_version = {
     dev  = "2.3.0--0"
     prod = "2.3.0--0--2990cf1"
-    stg  = "2.3.0--0--2990cf1"
+    stg  = "2.3.1--1--9344851"
   }
 
   umccrise_wfl_input = {


### PR DESCRIPTION
```
ica workflows versions list wfl.714e9172f3674023b210ccc7c47db05a -a $ICA_ACCESS_TOKEN_STG | head -n2
ID                                  	NAME             	LANGUAGE	STATUS  	TIMECREATED
wfv.4c633ea9a5b94c3e8cd7bd460fe831d8	2.3.1--1--9344851	CWL     	Released	2023-09-14 09:40:12.695 +1000 AEST
```