### PR TITLE
Portal TF: Rollback CodeBuild to LINUX_CONTAINER x86_64 Standard image

### DIFF
--- a/terraform/stacks/umccr_data_portal/cicd.tf
+++ b/terraform/stacks/umccr_data_portal/cicd.tf
@@ -291,8 +291,8 @@ resource "aws_codebuild_project" "codebuild_client" {
 
   environment {
     compute_type = "BUILD_GENERAL1_SMALL"
-    image        = "aws/codebuild/amazonlinux2-aarch64-standard:3.0"
-    type         = "ARM_CONTAINER"
+    image        = "aws/codebuild/standard:7.0"
+    type         = "LINUX_CONTAINER"
 
     environment_variable {
       name  = "STAGE"
@@ -375,8 +375,8 @@ resource "aws_codebuild_project" "codebuild_apis" {
 
   environment {
     compute_type    = "BUILD_GENERAL1_SMALL"
-    image           = "aws/codebuild/amazonlinux2-aarch64-standard:3.0"
-    type            = "ARM_CONTAINER"
+    image           = "aws/codebuild/standard:7.0"
+    type            = "LINUX_CONTAINER"
     privileged_mode = true
 
     environment_variable {

--- a/terraform/stacks/umccr_data_portal/data2.tf
+++ b/terraform/stacks/umccr_data_portal/data2.tf
@@ -265,8 +265,8 @@ resource "aws_codebuild_project" "codebuild_data2" {
 
   environment {
     compute_type = "BUILD_GENERAL1_SMALL"
-    image        = "aws/codebuild/amazonlinux2-aarch64-standard:3.0"
-    type         = "ARM_CONTAINER"
+    image        = "aws/codebuild/standard:7.0"
+    type         = "LINUX_CONTAINER"
 
     environment_variable {
       name  = "STAGE"


### PR DESCRIPTION
* See upstream Prism issue
  https://github.com/stoplightio/prism/issues/1966
