### PR TITLE
Portal TF: Added wts_alignment_qc workflow type SSM parameter

### DIFF
--- a/terraform/stacks/umccr_data_portal/workflow/wgs_alignment_qc.tf
+++ b/terraform/stacks/umccr_data_portal/workflow/wgs_alignment_qc.tf
@@ -18,7 +18,7 @@ locals {
   }
 }
 
-# --- DRAGEN WGS QC Workflow for WGS samples (used to call Germline initially)
+# --- DRAGEN WGS QC Workflow for WGS samples
 
 resource "aws_ssm_parameter" "wgs_alignment_qc_wfl_id" {
   name        = "/iap/workflow/wgs_alignment_qc/id"
@@ -40,6 +40,36 @@ resource "aws_ssm_parameter" "wgs_alignment_qc_wfl_input" {
   name        = "/iap/workflow/wgs_alignment_qc/input"
   type        = "String"
   description = "DRAGEN_WGS_QC Input JSON"
+  value       = local.wgs_alignment_qc_wfl_input[terraform.workspace]
+  tags        = merge(local.default_tags)
+}
+
+# --- DRAGEN WTS QC Workflow for WTS samples
+# For now, DRAGEN_WGS_QC and DRAGEN_WTS_QC workflows point to the same workflow at ICA CWL side.
+# See below:
+# https://github.com/umccr/data-portal-apis/pull/611
+# https://github.com/umccr/infrastructure/pull/334
+
+resource "aws_ssm_parameter" "wts_alignment_qc_wfl_id" {
+  name        = "/iap/workflow/wts_alignment_qc/id"
+  type        = "String"
+  description = "DRAGEN_WTS_QC Workflow ID"
+  value       = local.wgs_alignment_qc_wfl_id[terraform.workspace]
+  tags        = merge(local.default_tags)
+}
+
+resource "aws_ssm_parameter" "wts_alignment_qc_wfl_version" {
+  name        = "/iap/workflow/wts_alignment_qc/version"
+  type        = "String"
+  description = "DRAGEN_WTS_QC Workflow Version Name"
+  value       = local.wgs_alignment_qc_wfl_version[terraform.workspace]
+  tags        = merge(local.default_tags)
+}
+
+resource "aws_ssm_parameter" "wts_alignment_qc_wfl_input" {
+  name        = "/iap/workflow/wts_alignment_qc/input"
+  type        = "String"
+  description = "DRAGEN_WTS_QC Input JSON"
   value       = local.wgs_alignment_qc_wfl_input[terraform.workspace]
   tags        = merge(local.default_tags)
 }


### PR DESCRIPTION
* This is mandatory for SecondaryAnalysisHelper construct. At the mo,
  both wgs_alignment_qc and wts_alignment_qc are pointing to the same
  DRAGEN workflow at ICA CWL.
* This fixes Ocicat e2e run issue at QC step in DEV.

Related
* #334
* https://github.com/umccr/data-portal-apis/pull/611
