### PR TITLE
Portal TF: Reroute Portal DLQ alarms to proper Slack channels

### DIFF
--- a/terraform/stacks/umccr_data_portal/app/gds.tf
+++ b/terraform/stacks/umccr_data_portal/app/gds.tf
@@ -33,7 +33,7 @@ resource "aws_cloudwatch_metric_alarm" "ica_gds_event_dlq_alarm" {
   alarm_name = "DataPortalICAGDSEventSQSDLQ"
   alarm_description = "Data Portal ICA GDS Event SQS DLQ having > 0 messages"
   alarm_actions = [
-    data.aws_sns_topic.portal_ops_sns_topic.arn
+    local.notification_sns_topic_arn[terraform.workspace]
   ]
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods = 1

--- a/terraform/stacks/umccr_data_portal/app/main.tf
+++ b/terraform/stacks/umccr_data_portal/app/main.tf
@@ -37,10 +37,20 @@ locals {
     "Creator"     = "terraform"
     "Environment" = terraform.workspace
   }
+
+  notification_sns_topic_arn = {
+    prod = data.aws_sns_topic.portal_ops_sns_topic.arn
+    dev  = data.aws_sns_topic.chatbot_topic.arn
+    stg  = data.aws_sns_topic.chatbot_topic.arn
+  }
 }
 
 data "aws_sns_topic" "portal_ops_sns_topic" {
   name = "DataPortalTopic"
+}
+
+data "aws_sns_topic" "chatbot_topic" {
+  name = "AwsChatBotTopic"
 }
 
 # see each app resources in their own tf files: s3.tf, report.tf

--- a/terraform/stacks/umccr_data_portal/app/s3.tf
+++ b/terraform/stacks/umccr_data_portal/app/s3.tf
@@ -113,7 +113,7 @@ resource "aws_cloudwatch_metric_alarm" "s3_event_sqs_dlq_alarm" {
   alarm_name = "DataPortalS3EventSQSDLQ"
   alarm_description = "Data Portal S3 Events SQS DLQ having > 0 messages"
   alarm_actions = [
-    data.aws_sns_topic.portal_ops_sns_topic.arn
+    local.notification_sns_topic_arn[terraform.workspace]
   ]
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods = 1

--- a/terraform/stacks/umccr_data_portal/pipeline/main.tf
+++ b/terraform/stacks/umccr_data_portal/pipeline/main.tf
@@ -37,6 +37,12 @@ locals {
     "Creator"     = "terraform"
     "Environment" = terraform.workspace
   }
+
+  notification_sns_topic_arn = {
+    prod = data.aws_sns_topic.portal_ops_sns_topic.arn
+    dev  = data.aws_sns_topic.chatbot_topic.arn
+    stg  = data.aws_sns_topic.chatbot_topic.arn
+  }
 }
 
 data "aws_region" "current" {}
@@ -45,6 +51,10 @@ data "aws_caller_identity" "current" {}
 
 data "aws_sns_topic" "portal_ops_sns_topic" {
   name = "DataPortalTopic"
+}
+
+data "aws_sns_topic" "chatbot_topic" {
+  name = "AwsChatBotTopic"
 }
 
 # ---
@@ -88,7 +98,7 @@ resource "aws_cloudwatch_metric_alarm" "ica_ens_event_sqs_dlq_alarm" {
   alarm_name = "DataPortalIAPENSEventSQSDLQ"
   alarm_description = "Data Portal IAP ENS Event SQS DLQ having > 0 messages"
   alarm_actions = [
-    data.aws_sns_topic.portal_ops_sns_topic.arn
+    local.notification_sns_topic_arn[terraform.workspace]
   ]
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods = 1
@@ -140,7 +150,7 @@ resource "aws_cloudwatch_metric_alarm" "batch_event_sqs_dlq_alarm" {
   alarm_name        = "DataPortalBatchEventSQSDLQ"
   alarm_description = "Data Portal Batch Event SQS DLQ having > 0 messages"
   alarm_actions     = [
-    data.aws_sns_topic.portal_ops_sns_topic.arn
+    local.notification_sns_topic_arn[terraform.workspace]
   ]
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = 1


### PR DESCRIPTION
* Only keep PROD related DLQ alarms to #data-portal
* See https://umccr.slack.com/archives/CP356DDCH/p1697542395074139

prod > #data-portal
dev  > #arteria-dev
stg  > #devops-alerts
