### PR TITLE
CDK Bootstrap: Improve AWS CDK Bootstrap

### DIFF
--- a/scripts/all-accounts-aws-config.ini
+++ b/scripts/all-accounts-aws-config.ini
@@ -6,28 +6,123 @@
 ; sessions define the two sets of credentials needed for our accounts
 ;
 
-[sso-session umccr-bootstrap-session]
+[sso-session umccr]
 sso_start_url = https://umccr.awsapps.com/start
 sso_region = ap-southeast-2
 sso_registration_scopes = sso:account:access
 
-[sso-session unimelb-bootstrap-session]
+[sso-session unimelb]
 sso_start_url = https://unimelb.awsapps.com/start
 sso_region = ap-southeast-2
 sso_registration_scopes = sso:account:access
 
 ;
-; profiles define every account in our organisations
+; accounts from umccr tenancy
 ;
 
-[profile umccr-dev]
-sso_session = umccr-bootstrap-session
+[profile umccr-bastion-admin]
+sso_session = umccr
+sso_account_id = 383856791668
+sso_role_name = AdministratorAccess
+region = ap-southeast-2
+output = json
+cli_pager =
+
+[profile umccr-dev-admin]
+sso_session = umccr
 sso_account_id = 843407916570
 sso_role_name = AdministratorAccess
 region = ap-southeast-2
+cli_pager =
 
-[profile unimelb-australiangenomics]
-sso_session = unimelb-bootstrap-session
+[profile umccr-stg-admin]
+sso_session = umccr
+sso_account_id = 455634345446
+sso_role_name = AdministratorAccess
+region = ap-southeast-2
+output = json
+cli_pager =
+
+[profile umccr-prod-admin]
+sso_session = umccr
+sso_account_id = 472057503814
+sso_role_name = AdministratorAccess
+region = ap-southeast-2
+output = json
+cli_pager =
+
+[profile umccr-prod-operator]
+sso_session = umccr
+sso_account_id = 472057503814
+sso_role_name = ProdOperator
+region = ap-southeast-2
+output = json
+cli_pager =
+
+[profile umccr-agha-admin]
+sso_session = umccr
+sso_account_id = 602836945884
+sso_role_name = AdministratorAccess
+region = ap-southeast-2
+output = json
+cli_pager =
+
+[profile umccr-onboarding-admin]
+sso_session = umccr
+sso_account_id = 702956374523
+sso_role_name = AdministratorAccess
+region = ap-southeast-2
+output = json
+cli_pager =
+
+;
+; accounts from unimelb tenancy
+;
+
+[profile unimelb-toolchain-admin]
+sso_session = unimelb
+sso_account_id = 442639098081
+sso_role_name = AWSAdministratorAccess
+region = ap-southeast-2
+output = json
+cli_pager =
+
+[profile unimelb-australiangenomics-admin]
+sso_session = unimelb
 sso_account_id = 258177526432
 sso_role_name = AWSAdministratorAccess
 region = ap-southeast-2
+output = json
+cli_pager =
+
+[profile unimelb-data-admin]
+sso_session = unimelb
+sso_account_id = 503977275616
+sso_role_name = AWSAdministratorAccess
+region = ap-southeast-2
+output = json
+cli_pager =
+
+[profile unimelb-demo-admin]
+sso_session = unimelb
+sso_account_id = 534840902377
+sso_role_name = AWSAdministratorAccess
+region = ap-southeast-2
+output = json
+cli_pager =
+
+[profile unimelb-beta-admin]
+sso_session = unimelb
+sso_account_id = 042906701326
+sso_role_name = AWSAdministratorAccess
+region = ap-southeast-2
+output = json
+cli_pager =
+
+[profile unimelb-gamma-admin]
+sso_session = unimelb
+sso_account_id = 429147653657
+sso_role_name = AWSAdministratorAccess
+region = ap-southeast-2
+output = json
+cli_pager =

--- a/scripts/aws_bootstrap/README.md
+++ b/scripts/aws_bootstrap/README.md
@@ -1,0 +1,68 @@
+# aws_bootstrap
+
+See story https://trello.com/c/jn56wL6f
+
+
+## TL;DR
+
+* I want to update (make changes to) the [CDK bootstrap](https://docs.aws.amazon.com/cdk/v2/guide/bootstrapping.html) stack (i.e. `CDKToolkit`) in the specified AWS account, how?
+  * Make a PR to update/change request to the [bootstrap-template.yaml](bootstrap-template.yaml).
+  * Add PR review to Flo/Victor then to follow up with the steps below in AWS Console there.
+
+
+## Steps
+
+1. Prepare your AWS CLI config to align as prescribed in [all-accounts-aws-config.ini](../all-accounts-aws-config.ini).
+2. Login to have fresh SSO session:
+   ```
+   aws sso login --sso-session umccr
+   aws sso login --sso-session unimelb
+   ```
+3. Read to understand the notes in the script [bootstrap-update-all.sh](bootstrap-update-all.sh).
+4. Execute like so: `zsh bootstrap-update-all.sh`.
+5. Login to `AWS Console > CloudFormation > CDKToolkit > Change sets (tab) > Execute change set` to complete the process.
+6. If there is no changes to apply in the changeset, just simply delete your changeset that has created by the script execution.
+
+
+## Expect
+
+An example execution as follows:
+
+```
+zsh bootstrap-update-all.sh
+
+----------------------------
+Deploying CDK for account unimelb-toolchain-admin
+
+Waiting for changeset to be created..
+Changeset created successfully. Run the following command to review changes:
+aws cloudformation describe-change-set --change-set-name arn:aws:cloudformation:ap-southeast-2:1234567890:changeSet/awscli-cloudformation-package-deploy-1111333545/5762849b-5691-530f-bf44-605a24125fd3
+
+----------------------------
+Deploying CDK for account unimelb-demo-admin
+
+Waiting for changeset to be created..
+Changeset created successfully. Run the following command to review changes:
+aws cloudformation describe-change-set --change-set-name arn:aws:cloudformation:ap-southeast-2:<..snap..>
+
+----------------------------
+Deploying CDK for account unimelb-australiangenomics-admin
+
+Waiting for changeset to be created..
+Changeset created successfully. Run the following command to review changes:
+aws cloudformation describe-change-set --change-set-name arn:aws:cloudformation:ap-southeast-2:<..snap..>
+
+----------------------------
+Deploying CDK for account unimelb-beta-admin
+
+Waiting for changeset to be created..
+Changeset created successfully. Run the following command to review changes:
+aws cloudformation describe-change-set --change-set-name arn:aws:cloudformation:ap-southeast-2:<..snap..>
+
+----------------------------
+Deploying CDK for account unimelb-gamma-admin
+
+Waiting for changeset to be created..
+Changeset created successfully. Run the following command to review changes:
+aws cloudformation describe-change-set --change-set-name arn:aws:cloudformation:ap-southeast-2:<..snap..>
+```

--- a/scripts/aws_bootstrap/bootstrap-update-all.sh
+++ b/scripts/aws_bootstrap/bootstrap-update-all.sh
@@ -3,25 +3,30 @@
 # we have a config just for our infrastructure scripts
 all_config_path=$(realpath "../all-accounts-aws-config.ini")
 
-# specify exactly what accounts we want to bootstrap for CDK - and the corresponding trusted (build) account
+# list the account (profile name) that wish to bootstrap for CDK - and the corresponding trusted (build) account
 typeset -A cdks=(
-  'unimelb-australiangenomics' '442639098081'
-  'umccr-dev' '383856791668'
+  'unimelb-toolchain-admin' '442639098081'
+  'unimelb-australiangenomics-admin' '442639098081'
+  'unimelb-demo-admin' '442639098081'
+  'unimelb-beta-admin' '442639098081'
+  'unimelb-gamma-admin' '442639098081'
 )
 
 # prove we are admin humans in both organisations
-echo "Login with UMCCR AWS credentials"
-AWS_CONFIG_FILE=$all_config_path aws sso login --sso-session umccr-bootstrap-session
-echo "Login with UniMelb AWS credentials"
-AWS_CONFIG_FILE=$all_config_path aws sso login --sso-session unimelb-bootstrap-session
+#echo "Login with UMCCR AWS credentials"
+#AWS_CONFIG_FILE=$all_config_path aws sso login --sso-session umccr
+#echo "Login with UniMelb AWS credentials"
+#AWS_CONFIG_FILE=$all_config_path aws sso login --sso-session unimelb
 
 # now deploy the CDK template across all listed accounts
 for k v ("${(@kv)cdks}");
 do
+  echo "----------------------------"
   echo "Deploying CDK for account $k"
   AWS_CONFIG_FILE=$all_config_path aws \
                                 --profile "$k" \
                                 cloudformation deploy \
+                                --no-execute-changeset \
                                 --stack-name CDKToolkit \
                                 --template-file $(realpath bootstrap-template.yaml) \
                                 --parameter-overrides \
@@ -30,5 +35,19 @@ do
                                   'PublicAccessBlockConfiguration=false' \
                                   'CloudFormationExecutionPolicies=arn:aws:iam::aws:policy/AdministratorAccess' \
                                   'FileAssetsBucketKmsKeyId=AWS_MANAGED_KEY' \
-                                --capabilities "CAPABILITY_NAMED_IAM"
+                                --capabilities "CAPABILITY_NAMED_IAM" \
+                                --tags "Stack=aws_bootstrap"
 done
+
+# Note 1:
+# At this script stand, it will only create stack changeset and, pause there.
+# To apply the changeset, please login to `AWS Console > CloudFormation > CDKToolkit > Change sets (tab) > Execute the change set`
+# This is the intentional for now
+
+# Note 2:
+# We set PublicAccessBlockConfiguration to false due to UoM role permission issue
+# See issue and uom slack thread below
+# https://github.com/aws/aws-cdk/issues/8724
+# https://unimelb.slack.com/archives/C05A22M4B4L/p1693437379860939
+#
+# The equivalent of CLI command:  `cdk bootstrap --public-access-block-configuration=false`

--- a/terraform/stacks/cdk_bootstrap/README.md
+++ b/terraform/stacks/cdk_bootstrap/README.md
@@ -1,4 +1,10 @@
-# CDK Bootstrap
+# CDK Bootstrap (DEPRECATED)
+
+> !!! THIS STACK IS DEPRECATED AND NO LONGER USE. SEE [aws_bootstrap](../../../scripts/aws_bootstrap) !!!
+> THIS STACK IS SCHEDULED TO BE RECYCLED AT SOME POINT... ALL TF WORKSPACE AND STATE HAVE BEEN DETACHED AND WIPED.
+
+
+---
 
 See story https://trello.com/c/jn56wL6f
 

--- a/terraform/stacks/cdk_bootstrap/main.tf
+++ b/terraform/stacks/cdk_bootstrap/main.tf
@@ -29,7 +29,7 @@ resource "aws_cloudformation_stack" "CDKToolkit" {
   parameters = {
     CloudFormationExecutionPolicies = "arn:aws:iam::aws:policy/AdministratorAccess"  # TODO perhaps further refinement, see README > Trello card
     FileAssetsBucketKmsKeyId        = "AWS_MANAGED_KEY"
-    PublicAccessBlockConfiguration  = true
+    PublicAccessBlockConfiguration  = false  # See https://github.com/aws/aws-cdk/issues/8724 and https://unimelb.slack.com/archives/C05A22M4B4L/p1693437379860939
     // trust the toolchain account for CDK pipeline deployments
     TrustedAccounts                 = "442639098081"
     UseExamplePermissionsBoundary   = false


### PR DESCRIPTION
* Made it to `--no-execute-changeset` at changeset pending stage
  and, let AdminOps follow up with AWS CloudFormation Console for
  the actual execution. This process flow is intentional.
* Added notes and README.md
* Improved and established AWS Account profile name convention over
  differing tenancy i.e. umccr and unimelb.