### PR TITLE
Portal TF: Enable SSE for SQS queues

### DIFF
--- a/terraform/stacks/umccr_data_portal/app/gds.tf
+++ b/terraform/stacks/umccr_data_portal/app/gds.tf
@@ -4,6 +4,7 @@
 resource "aws_sqs_queue" "ica_gds_event_dlq" {
   name = "${local.stack_name_dash}-ica-gds-event-dlq"
   message_retention_seconds = 1209600
+  sqs_managed_sse_enabled = true
   tags = merge(local.default_tags)
 }
 
@@ -18,6 +19,7 @@ resource "aws_sqs_queue" "ica_gds_event_queue" {
     maxReceiveCount = 3
   })
   visibility_timeout_seconds = 30*6  # lambda function timeout * 6
+  sqs_managed_sse_enabled = true
 
   tags = merge(local.default_tags)
 }

--- a/terraform/stacks/umccr_data_portal/app/s3.tf
+++ b/terraform/stacks/umccr_data_portal/app/s3.tf
@@ -43,6 +43,7 @@ data "aws_s3_bucket" "s3_oncoanalyser_bucket" {
 resource "aws_sqs_queue" "s3_event_dlq" {
   name = "${local.stack_name_dash}-${terraform.workspace}-s3-event-dlq"
   message_retention_seconds = 1209600
+  sqs_managed_sse_enabled = true
   tags = merge(local.default_tags)
 }
 
@@ -61,7 +62,7 @@ resource "aws_sqs_queue" "s3_event_queue" {
     maxReceiveCount = 20
   })
   visibility_timeout_seconds = 30*6  # lambda function timeout * 6
-
+  sqs_managed_sse_enabled = true
   tags = merge(local.default_tags)
 }
 
@@ -107,6 +108,8 @@ resource "aws_s3_bucket_notification" "oncoanalyser_notification" {
 
     filter_prefix = "analysis_data/"
   }
+
+  eventbridge = true
 }
 
 resource "aws_cloudwatch_metric_alarm" "s3_event_sqs_dlq_alarm" {

--- a/terraform/stacks/umccr_data_portal/pipeline/holmes.tf
+++ b/terraform/stacks/umccr_data_portal/pipeline/holmes.tf
@@ -12,6 +12,7 @@ resource "aws_sqs_queue" "somalier_extract_queue" {
   fifo_queue = true
   content_based_deduplication = true
   visibility_timeout_seconds = 30*6  # lambda function timeout * 6
+  sqs_managed_sse_enabled = true
   tags = merge(local.default_tags)
 }
 

--- a/terraform/stacks/umccr_data_portal/pipeline/ica.tf
+++ b/terraform/stacks/umccr_data_portal/pipeline/ica.tf
@@ -14,6 +14,7 @@ resource "aws_sqs_queue" "notification_queue" {
   content_based_deduplication = true
   delay_seconds = 5
   visibility_timeout_seconds = 30*6  # lambda function timeout * 6
+  sqs_managed_sse_enabled = true
   tags = merge(local.default_tags)
 }
 
@@ -31,6 +32,7 @@ resource "aws_sqs_queue" "dragen_wgs_qc_queue" {
   fifo_queue = true
   content_based_deduplication = true
   visibility_timeout_seconds = 30*6  # lambda function timeout * 6
+  sqs_managed_sse_enabled = true
   tags = merge(local.default_tags)
 }
 
@@ -48,6 +50,7 @@ resource "aws_sqs_queue" "dragen_tso_ctdna_queue" {
   fifo_queue = true
   content_based_deduplication = true
   visibility_timeout_seconds = 30*6  # lambda function timeout * 6
+  sqs_managed_sse_enabled = true
   tags = merge(local.default_tags)
 }
 
@@ -65,6 +68,7 @@ resource "aws_sqs_queue" "tn_queue" {
   fifo_queue = true
   content_based_deduplication = true
   visibility_timeout_seconds = 30*6  # lambda function timeout * 6
+  sqs_managed_sse_enabled = true
   tags = merge(local.default_tags)
 }
 
@@ -82,6 +86,7 @@ resource "aws_sqs_queue" "dragen_wts_queue" {
   fifo_queue = true
   content_based_deduplication = true
   visibility_timeout_seconds = 30*6  # lambda function timeout * 6
+  sqs_managed_sse_enabled = true
   tags = merge(local.default_tags)
 }
 
@@ -99,6 +104,7 @@ resource "aws_sqs_queue" "umccrise_queue" {
   fifo_queue = true
   content_based_deduplication = true
   visibility_timeout_seconds = 30*6  # lambda function timeout * 6
+  sqs_managed_sse_enabled = true
   tags = merge(local.default_tags)
 }
 
@@ -116,6 +122,7 @@ resource "aws_sqs_queue" "rnasum_queue" {
   fifo_queue = true
   content_based_deduplication = true
   visibility_timeout_seconds = 30*6  # lambda function timeout * 6
+  sqs_managed_sse_enabled = true
   tags = merge(local.default_tags)
 }
 

--- a/terraform/stacks/umccr_data_portal/pipeline/main.tf
+++ b/terraform/stacks/umccr_data_portal/pipeline/main.tf
@@ -69,6 +69,7 @@ data "aws_sns_topic" "chatbot_topic" {
 resource "aws_sqs_queue" "iap_ens_event_dlq" {
   name = "${local.stack_name_dash}-${terraform.workspace}-iap-ens-event-dlq"
   message_retention_seconds = 1209600
+  sqs_managed_sse_enabled = true
   tags = merge(local.default_tags)
 }
 
@@ -83,7 +84,7 @@ resource "aws_sqs_queue" "iap_ens_event_queue" {
     maxReceiveCount = 3
   })
   visibility_timeout_seconds = 30*6  # lambda function timeout * 6
-
+  sqs_managed_sse_enabled = true
   tags = merge(local.default_tags)
 }
 
@@ -121,6 +122,7 @@ resource "aws_cloudwatch_metric_alarm" "ica_ens_event_sqs_dlq_alarm" {
 resource "aws_sqs_queue" "batch_event_dlq" {
   name                      = "${local.stack_name_dash}-batch-event-dlq"
   message_retention_seconds = 1209600
+  sqs_managed_sse_enabled   = true
   tags                      = merge(local.default_tags)
 }
 
@@ -136,6 +138,7 @@ resource "aws_sqs_queue" "batch_event_queue" {
   })
 
   visibility_timeout_seconds = 30*6  # lambda function timeout * 6
+  sqs_managed_sse_enabled    = true
   tags                       = merge(local.default_tags)
 }
 

--- a/terraform/stacks/umccr_data_portal/pipeline/oncoanalyser.tf
+++ b/terraform/stacks/umccr_data_portal/pipeline/oncoanalyser.tf
@@ -51,6 +51,7 @@ resource "aws_sqs_queue" "star_alignment_queue" {
   fifo_queue = true
   content_based_deduplication = true
   visibility_timeout_seconds = 30*6  # lambda function timeout * 6
+  sqs_managed_sse_enabled = true
   tags = merge(local.default_tags)
 }
 
@@ -68,6 +69,7 @@ resource "aws_sqs_queue" "oncoanalyser_wts_queue" {
   fifo_queue = true
   content_based_deduplication = true
   visibility_timeout_seconds = 30*6  # lambda function timeout * 6
+  sqs_managed_sse_enabled = true
   tags = merge(local.default_tags)
 }
 
@@ -85,6 +87,7 @@ resource "aws_sqs_queue" "oncoanalyser_wgs_queue" {
   fifo_queue = true
   content_based_deduplication = true
   visibility_timeout_seconds = 30*6  # lambda function timeout * 6
+  sqs_managed_sse_enabled = true
   tags = merge(local.default_tags)
 }
 
@@ -102,6 +105,7 @@ resource "aws_sqs_queue" "oncoanalyser_wgts_queue" {
   fifo_queue = true
   content_based_deduplication = true
   visibility_timeout_seconds = 30*6  # lambda function timeout * 6
+  sqs_managed_sse_enabled = true
   tags = merge(local.default_tags)
 }
 
@@ -119,6 +123,7 @@ resource "aws_sqs_queue" "sash_queue" {
   fifo_queue = true
   content_based_deduplication = true
   visibility_timeout_seconds = 30*6  # lambda function timeout * 6
+  sqs_managed_sse_enabled = true
   tags = merge(local.default_tags)
 }
 


### PR DESCRIPTION
* SecurityHub KPI
  [SQS.1] Amazon SQS queues should be encrypted at rest
  https://docs.aws.amazon.com/securityhub/latest/userguide/sqs-controls.html#sqs-1