### PR TITLE
Cognito AAI TF: Implemented a way to create Service User with Cognito

### DIFF
--- a/terraform/stacks/cognito_aai/app_data_portal_data2.tf
+++ b/terraform/stacks/cognito_aai/app_data_portal_data2.tf
@@ -37,7 +37,7 @@ locals {
 resource "aws_cognito_user_pool_client" "data2_client" {
   name                         = "${local.portal}-app2-${terraform.workspace}"
   user_pool_id                 = aws_cognito_user_pool.user_pool.id
-  supported_identity_providers = ["Google"]
+  supported_identity_providers = ["Google", "COGNITO"]
 
   callback_urls = local.data2_callback_urls[terraform.workspace]
   logout_urls   = local.data2_callback_urls[terraform.workspace]

--- a/terraform/stacks/cognito_aai/main.tf
+++ b/terraform/stacks/cognito_aai/main.tf
@@ -37,6 +37,8 @@ locals {
   ssm_param_key_client_prefix = "/${local.stack_name_us}/client"  # pls note this namespace param has few references
 }
 
+data "aws_region" "current" {}
+
 ################################################################################
 # Query for Pre-configured SSM Parameter Store
 # These are pre-populated outside of terraform i.e. manually using Console or CLI

--- a/terraform/stacks/cognito_aai/outputs.tf
+++ b/terraform/stacks/cognito_aai/outputs.tf
@@ -9,3 +9,9 @@ output "cognito_identity_pool_id" {
 output "cognito_oauth_domain" {
   value = aws_cognito_user_pool_domain.user_pool_domain.domain
 }
+
+# Construct login URL for the Cognito built-in Hosted UI with Portal App Client
+# https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pools-app-integration.html#cognito-user-pools-app-integration-view-hosted-ui
+output "portal_client_hosted_ui" {
+  value = "https://${aws_cognito_user_pool_domain.user_pool_domain.domain}.auth.${data.aws_region.current.name}.amazoncognito.com/oauth2/authorize?client_id=${aws_cognito_user_pool_client.data2_client.id}&response_type=code&redirect_uri=${local.data2_oauth_redirect_url[terraform.workspace]}"
+}

--- a/terraform/stacks/cognito_aai/users.tf
+++ b/terraform/stacks/cognito_aai/users.tf
@@ -1,0 +1,45 @@
+### NOTE:
+# How to provision new Service User to Cognito AAI
+#
+# This TF resource use Cognito `AdminCreateUser` flow to create new user as an admin. Cognito sends the temporary
+# password to designated email address. The user will be created with `FORCE_CHANGE_PASSWORD` state until
+# the user sign in and change the password.
+#
+# AdminCreateUser
+# API: https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_AdminCreateUser.html
+# CLI: https://awscli.amazonaws.com/v2/documentation/api/latest/reference/cognito-idp/admin-create-user.html
+# TF:  https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cognito_user
+#
+# Hosted UI
+# Couple of ways to get the Cognito Hosted (login) UI page. As follows.
+#
+# 1) terraform output
+# Just run `terraform output` and look for value `portal_client_hosted_ui` in the output.
+#
+# 2) AWS Console
+# Cognito > User pools > data-portal-dev > (select App client) App client: data-portal-app2-dev
+#   > at Hosted UI section
+#   > View Hosted UI button
+#   > (right click & copy link address)
+#
+# Activating the User
+# After terraform apply, please follow the login page once; to reset the password & activate the service user.
+#
+# Deleting the User
+# To avoid confusion, please do not use Cognito Console or AWS CLI (though it is unharmed if you do). It is better to
+# deregister through here with terraform. Just simply remove the corresponding block below and terraform apply. Just
+# think of as like tracking IAM users being managed in terraform.
+###
+
+resource "aws_cognito_user" "orcabus_token_service_user" {
+  # Required by https://github.com/umccr/orcabus/pull/197
+  user_pool_id             = aws_cognito_user_pool.user_pool.id
+  username                 = "orcabus.api.${terraform.workspace}"
+  enabled                  = true
+  desired_delivery_mediums = ["EMAIL"]
+
+  attributes = {
+    email          = "services+orcabus.api.${terraform.workspace}@umccr.org"
+    email_verified = true
+  }
+}


### PR DESCRIPTION
* Enabled COGNITO as supported IdP for Portal app client
* Added `users.tf` to track Portal Service User registry.
  See its TF docstring for details.

Related
https://github.com/umccr/orcabus/pull/197
