### PR TITLE
Portal TF: Deprecated data domain and related SSL SSM parameters

### DIFF
--- a/terraform/stacks/umccr_data_portal/backend.tf
+++ b/terraform/stacks/umccr_data_portal/backend.tf
@@ -1,13 +1,6 @@
 ################################################################################
 # Back end configurations
 
-data "aws_acm_certificate" "backend_cert" {
-  domain   = local.app_domain
-  statuses = ["ISSUED"]
-}
-
-# FIXME: https://github.com/umccr/infrastructure/issues/272
-#  To deprecate/replace above `app_domain` with the following
 data "aws_acm_certificate" "backend_cert2" {
   domain   = local.app_domain2
   statuses = ["ISSUED"]
@@ -132,14 +125,6 @@ resource "aws_ssm_parameter" "lambda_security_group_ids" {
   tags  = merge(local.default_tags)
 }
 
-resource "aws_ssm_parameter" "api_domain_name" {
-  name  = "${local.ssm_param_key_backend_prefix}/api_domain_name"
-  type  = "String"
-  value = local.api_domain
-  tags  = merge(local.default_tags)
-}
-
-# FIXME: https://github.com/umccr/infrastructure/issues/272
 resource "aws_ssm_parameter" "api_domain_name2" {
   name  = "${local.ssm_param_key_backend_prefix}/api_domain_name2"
   type  = "String"
@@ -147,14 +132,6 @@ resource "aws_ssm_parameter" "api_domain_name2" {
   tags  = merge(local.default_tags)
 }
 
-resource "aws_ssm_parameter" "certificate_arn" {
-  name  = "${local.ssm_param_key_backend_prefix}/certificate_arn"
-  type  = "String"
-  value = data.aws_acm_certificate.backend_cert.arn
-  tags  = merge(local.default_tags)
-}
-
-# FIXME: https://github.com/umccr/infrastructure/issues/272
 resource "aws_ssm_parameter" "certificate_arn2" {
   name  = "${local.ssm_param_key_backend_prefix}/certificate_arn2"
   type  = "String"

--- a/terraform/stacks/umccr_data_portal/backend.tf
+++ b/terraform/stacks/umccr_data_portal/backend.tf
@@ -125,10 +125,26 @@ resource "aws_ssm_parameter" "lambda_security_group_ids" {
   tags  = merge(local.default_tags)
 }
 
+# retain ssm param for backward compatibility and point to newer Portal domain
+resource "aws_ssm_parameter" "api_domain_name" {
+  name  = "${local.ssm_param_key_backend_prefix}/api_domain_name"
+  type  = "String"
+  value = local.api_domain2
+  tags  = merge(local.default_tags)
+}
+
 resource "aws_ssm_parameter" "api_domain_name2" {
   name  = "${local.ssm_param_key_backend_prefix}/api_domain_name2"
   type  = "String"
   value = local.api_domain2
+  tags  = merge(local.default_tags)
+}
+
+# retain ssm param for backward compatibility and point to newer Portal domain SSL cert
+resource "aws_ssm_parameter" "certificate_arn" {
+  name  = "${local.ssm_param_key_backend_prefix}/certificate_arn"
+  type  = "String"
+  value = data.aws_acm_certificate.backend_cert2.arn
   tags  = merge(local.default_tags)
 }
 


### PR DESCRIPTION
* This removes the following exported system parameters:
  ```
  /data_portal/backend/api_domain_name
  /data_portal/backend/certificate_arn
  ```
* At consumer side, these should be replaced new system parameter coordinate at:
  ```
  /data_portal/backend/api_domain_name2
  /data_portal/backend/certificate_arn2
  ```
* This will go multiple stages and this is the Phase 1 of
  https://github.com/umccr/infrastructure/issues/272
