### PR TITLE
TF data archive: update bucket name to match convention

### DIFF
--- a/terraform/stacks/data_archive/byob_ica_v2.tf
+++ b/terraform/stacks/data_archive/byob_ica_v2.tf
@@ -4,8 +4,9 @@
 locals {
   # The bucket holding all "active" production data
   pipeline_data_bucket_name = "${data.aws_caller_identity.current.account_id}-pipeline-cache"
+  pipeline_data_bucket_name_prod = "pipeline-prod-cache-${data.aws_caller_identity.current.account_id}-${data.aws_region.current.name}"
   # The bucket holding all development data
-  development_data_bucket_name = "${data.aws_caller_identity.current.account_id}-dev-cache"
+  pipeline_data_bucket_name_dev = "pipeline-dev-cache-${data.aws_caller_identity.current.account_id}-${data.aws_region.current.name}"
   # prefix for the BYOB data in ICAv2
   icav2_prefix = "byob-icav2/"
 }
@@ -133,15 +134,134 @@ resource "aws_s3_bucket_cors_configuration" "pipeline_data" {
 }
 
 # ------------------------------------------------------------------------------
-# development data
+# production data
 
-resource "aws_s3_bucket" "development_data" {
-  bucket = local.development_data_bucket_name
+resource "aws_s3_bucket" "production_data" {
+  bucket = local.pipeline_data_bucket_name_prod
 
   tags = merge(
     local.default_tags,
     {
-      "Name"=local.development_data_bucket_name
+      "Name"=local.pipeline_data_bucket_name_prod
+    }
+  )
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "production_data" {
+  bucket = aws_s3_bucket.production_data.bucket
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_versioning" "production_data" {
+  bucket = aws_s3_bucket.production_data.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "production_data" {
+  # Must have bucket versioning enabled first to apply noncurrent version expiration
+  depends_on = [aws_s3_bucket_versioning.production_data]
+
+  bucket = aws_s3_bucket.production_data.bucket
+
+  rule {
+    id = "base_rule"
+    status = "Enabled"
+    expiration {
+      expired_object_delete_marker = true
+    }
+    noncurrent_version_expiration {
+      noncurrent_days = 7
+    }
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 7
+    }
+  }
+
+  rule {
+    id = "icav2_data_it_rule"
+    status = "Enabled"
+    filter {
+      prefix = "${local.icav2_prefix}"
+    }
+    transition {
+      days          = 0
+      storage_class = "INTELLIGENT_TIERING"
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "production_data" {
+  bucket = aws_s3_bucket.production_data.id
+  policy = data.aws_iam_policy_document.production_data.json
+}
+
+data "aws_iam_policy_document" "production_data" {
+  statement {
+	  sid = "prod_lo_access"
+    principals {
+      type        = "AWS"
+      identifiers = ["472057503814"]
+    }
+    actions = [
+      "s3:List*",
+      "s3:GetBucketLocation",
+    ]
+    resources = [
+      aws_s3_bucket.production_data.arn,
+      "${aws_s3_bucket.production_data.arn}/*",
+    ]
+  }
+  statement {
+	  sid = "icav2_cross_account_access"
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::079623148045:role/ica_aps2_crossacct"]
+    }
+    actions = [
+      "s3:PutObject",
+      "s3:ListMultipartUploadParts",
+      "s3:AbortMultipartUpload",
+      "s3:GetObject"
+    ]
+    resources = [
+      aws_s3_bucket.production_data.arn,
+      "${aws_s3_bucket.production_data.arn}/*",
+    ]
+  }
+}
+
+# CORS configuration for ILMN BYO buckets to support UI uploads
+# ref: https://help.ica.illumina.com/home/h-storage/s-awss3
+resource "aws_s3_bucket_cors_configuration" "production_data" {
+  bucket = aws_s3_bucket.production_data.id
+
+  cors_rule {
+    allowed_headers = ["*"]
+    allowed_methods = ["HEAD", "GET", "PUT", "POST", "DELETE"]
+    allowed_origins = ["https://ica.illumina.com"]
+    expose_headers  = ["ETag", "x-amz-meta-custom-header"]
+    max_age_seconds = 3000
+  }
+}
+
+# ------------------------------------------------------------------------------
+# development data
+
+resource "aws_s3_bucket" "development_data" {
+  bucket = local.pipeline_data_bucket_name_dev
+
+  tags = merge(
+    local.default_tags,
+    {
+      "Name"=local.pipeline_data_bucket_name_dev
     }
   )
 }

--- a/terraform/stacks/data_archive/byob_ica_v2.tf
+++ b/terraform/stacks/data_archive/byob_ica_v2.tf
@@ -7,8 +7,13 @@ locals {
   pipeline_data_bucket_name_prod = "pipeline-prod-cache-${data.aws_caller_identity.current.account_id}-${data.aws_region.current.name}"
   # The bucket holding all development data
   pipeline_data_bucket_name_dev = "pipeline-dev-cache-${data.aws_caller_identity.current.account_id}-${data.aws_region.current.name}"
+  # The bucket holding all staging data
+  pipeline_data_bucket_name_stg = "staging-dev-cache-${data.aws_caller_identity.current.account_id}-${data.aws_region.current.name}"
   # prefix for the BYOB data in ICAv2
   icav2_prefix = "byob-icav2/"
+  account_id_prod = "472057503814"
+  account_id_stg = "455634345446"
+  account_id_dev = "843407916570"
 }
 
 ################################################################################
@@ -208,7 +213,7 @@ data "aws_iam_policy_document" "production_data" {
 	  sid = "prod_lo_access"
     principals {
       type        = "AWS"
-      identifiers = ["472057503814"]
+      identifiers = [local.account_id_prod]
     }
     actions = [
       "s3:List*",
@@ -242,6 +247,125 @@ data "aws_iam_policy_document" "production_data" {
 # ref: https://help.ica.illumina.com/home/h-storage/s-awss3
 resource "aws_s3_bucket_cors_configuration" "production_data" {
   bucket = aws_s3_bucket.production_data.id
+
+  cors_rule {
+    allowed_headers = ["*"]
+    allowed_methods = ["HEAD", "GET", "PUT", "POST", "DELETE"]
+    allowed_origins = ["https://ica.illumina.com"]
+    expose_headers  = ["ETag", "x-amz-meta-custom-header"]
+    max_age_seconds = 3000
+  }
+}
+
+# ------------------------------------------------------------------------------
+# staging data
+
+resource "aws_s3_bucket" "staging_data" {
+  bucket = local.pipeline_data_bucket_name_stg
+
+  tags = merge(
+    local.default_tags,
+    {
+      "Name"=local.pipeline_data_bucket_name_stg
+    }
+  )
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "staging_data" {
+  bucket = aws_s3_bucket.staging_data.bucket
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_versioning" "staging_data" {
+  bucket = aws_s3_bucket.staging_data.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "staging_data" {
+  # Must have bucket versioning enabled first to apply noncurrent version expiration
+  depends_on = [aws_s3_bucket_versioning.staging_data]
+
+  bucket = aws_s3_bucket.staging_data.bucket
+
+  rule {
+    id = "base_rule"
+    status = "Enabled"
+    expiration {
+      expired_object_delete_marker = true
+    }
+    noncurrent_version_expiration {
+      noncurrent_days = 30
+    }
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 7
+    }
+  }
+
+  rule {
+    id = "icav2_data_it_rule"
+    status = "Enabled"
+    filter {
+      prefix = "${local.icav2_prefix}"
+    }
+    transition {
+      days          = 0
+      storage_class = "INTELLIGENT_TIERING"
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "staging_data" {
+  bucket = aws_s3_bucket.staging_data.id
+  policy = data.aws_iam_policy_document.staging_data.json
+}
+
+data "aws_iam_policy_document" "staging_data" {
+  statement {
+	  sid = "stg_lo_access"
+    principals {
+      type        = "AWS"
+      identifiers = [local.account_id_stg]
+    }
+    actions = [
+      "s3:List*",
+      "s3:GetBucketLocation",
+    ]
+    resources = [
+      aws_s3_bucket.staging_data.arn,
+      "${aws_s3_bucket.staging_data.arn}/*",
+    ]
+  }
+  statement {
+	  sid = "icav2_cross_account_access"
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::079623148045:role/ica_aps2_crossacct"]
+    }
+    actions = [
+      "s3:PutObject",
+      "s3:ListMultipartUploadParts",
+      "s3:AbortMultipartUpload",
+      "s3:GetObject"
+    ]
+    resources = [
+      aws_s3_bucket.staging_data.arn,
+      "${aws_s3_bucket.staging_data.arn}/*",
+    ]
+  }
+}
+
+# CORS configuration for ILMN BYO buckets to support UI uploads
+# ref: https://help.ica.illumina.com/home/h-storage/s-awss3
+resource "aws_s3_bucket_cors_configuration" "staging_data" {
+  bucket = aws_s3_bucket.staging_data.id
 
   cors_rule {
     allowed_headers = ["*"]
@@ -307,10 +431,10 @@ resource "aws_s3_bucket_policy" "development_data" {
 
 data "aws_iam_policy_document" "development_data" {
   statement {
-	  sid = "prod_lo_access"
+	  sid = "dev_lo_access"
     principals {
       type        = "AWS"
-      identifiers = ["472057503814"]
+      identifiers = [local.account_id_dev]
     }
     actions = [
       "s3:List*",

--- a/terraform/stacks/data_archive/fastq_archive.tf
+++ b/terraform/stacks/data_archive/fastq_archive.tf
@@ -3,7 +3,8 @@
 
 locals {
   # The bucket holding all archived FASTQ data
-  fastq_archive_bucket_name = "${data.aws_caller_identity.current.account_id}-fastq-archive"
+  # fastq_archive_bucket_name = "${data.aws_caller_identity.current.account_id}-fastq-archive"
+  fastq_archive_bucket_name = "archive-prod-fastq-${data.aws_caller_identity.current.account_id}-${data.aws_region.current.name}"
 }
 
 ################################################################################

--- a/terraform/stacks/data_archive/raw_data_archive.tf
+++ b/terraform/stacks/data_archive/raw_data_archive.tf
@@ -1,3 +1,8 @@
+
+locals {
+  raw_data_bucket_name = "archive-prod-sequencing-data-${data.aws_caller_identity.current.account_id}-${data.aws_region.current.name}"
+}
+
 ################################################################################
 # Buckets
 


### PR DESCRIPTION
Updated bucket names for pipeline dev and fastq archive buckets
Added new pipeline prod bucket (old one to be removed when ICAv2 projects are "removed")
Added raw data bucket name template (note: not applied as no current need)
