### PR TITLE
modify status page callback and redirect url in dev env

### DIFF
--- a/terraform/stacks/cognito_aai/app_status_page.tf
+++ b/terraform/stacks/cognito_aai/app_status_page.tf
@@ -6,26 +6,23 @@
 locals {
   status_page   = "data-portal-status-page"
 
-  status_page_domain = "status.data.${var.base_domain[terraform.workspace]}"
+  status_page_domain = "status.${var.base_domain[terraform.workspace]}"
 
   status_page_alias_domain = {
-    prod = "status.data.umccr.org"
+    prod = "status.umccr.org"
     dev  = ""
     stg  = ""
   }
 
-  # FIXME: remove this when status page and apis is ready in production, https://github.com/umccr/data-portal-status-page/issues/105
-  status_page_dev_domain = "status.${var.base_domain[terraform.workspace]}"
-
   status_page_callback_urls = {
     prod = ["https://${local.status_page_domain}", "https://${local.status_page_alias_domain[terraform.workspace]}"]
-    dev  = ["https://${local.status_page_dev_domain}"]
+    dev  = ["https://${local.status_page_domain}"]
     stg  = ["https://${local.status_page_domain}"]
   }
 
   status_page_oauth_redirect_url = {
     prod = "https://${local.status_page_alias_domain[terraform.workspace]}"
-    dev  = "https://${local.status_page_dev_domain}"
+    dev  = "https://${local.status_page_domain}"
     stg  = "https://${local.status_page_domain}"
   }
 

--- a/terraform/stacks/cognito_aai/app_status_page.tf
+++ b/terraform/stacks/cognito_aai/app_status_page.tf
@@ -14,15 +14,18 @@ locals {
     stg  = ""
   }
 
+  # FIXME: remove this when status page and apis is ready in production, https://github.com/umccr/data-portal-status-page/issues/105
+  status_page_dev_domain = "status.${var.base_domain[terraform.workspace]}"
+
   status_page_callback_urls = {
     prod = ["https://${local.status_page_domain}", "https://${local.status_page_alias_domain[terraform.workspace]}"]
-    dev  = ["https://${local.status_page_domain}"]
+    dev  = ["https://${local.status_page_dev_domain}"]
     stg  = ["https://${local.status_page_domain}"]
   }
 
   status_page_oauth_redirect_url = {
     prod = "https://${local.status_page_alias_domain[terraform.workspace]}"
-    dev  = "https://${local.status_page_domain}"
+    dev  = "https://${local.status_page_dev_domain}"
     stg  = "https://${local.status_page_domain}"
   }
 


### PR DESCRIPTION
So far, we just need have new domain applied in our dev env. 

So only apply the the new callback and redirect url 
`status_page_dev_domain = "status.${var.base_domain[terraform.workspace]}"` 
in the dev env first in our cognito service.

Link issue https://github.com/umccr/data-portal-status-page/issues/105