### PR TITLE
Portal TF: Added Portal S3 indexer to ICAv2 pipeline cache bucket for ctTSOv2 result

### DIFF
--- a/terraform/stacks/umccr_data_portal/app/main.tf
+++ b/terraform/stacks/umccr_data_portal/app/main.tf
@@ -45,6 +45,10 @@ locals {
   }
 }
 
+data "aws_caller_identity" "current" {}
+
+data "aws_region" "current" {}
+
 data "aws_sns_topic" "portal_ops_sns_topic" {
   name = "DataPortalTopic"
 }


### PR DESCRIPTION
* While building OrcaBus actively, we use current Portal to show ctTSOv2 output as new tab.
  * https://github.com/umccr/infrastructure/issues/434
  * https://github.com/umccr/data-portal-apis/issues/684

* Once new output path convention is stable, we can statically filter prefix only to subscribe cttsov2.
  * https://github.com/umccr/orcabus/pull/350

* Related FileManager PR
  * https://github.com/umccr/orcabus/pull/351
