### PR TITLE
Add s3 bucket read permission for role authenticated policy

### DIFF
--- a/terraform/stacks/cognito_aai/policies/iam_role_authenticated_policy.json
+++ b/terraform/stacks/cognito_aai/policies/iam_role_authenticated_policy.json
@@ -8,7 +8,9 @@
         "cognito-sync:*",
         "cognito-identity:*"
       ],
-      "Resource": ["*"]
+      "Resource": [
+        "*"
+      ]
     },
     {
       "Effect": "Allow",
@@ -17,7 +19,19 @@
         "lambda:InvokeFunctionUrl",
         "lambda:InvokeFunction"
       ],
-      "Resource": ["*"]
+      "Resource": [
+        "*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:ListBucket",
+        "s3:GetObject"
+      ],
+      "Resource": [
+        "*"
+      ]
     }
   ]
 }


### PR DESCRIPTION
### Context:
For [static report issue](https://github.com/umccr/data-portal-status-page/issues/108), we need have bucket "read permission" (List and get objects) for role authenticated policy of our identity pool.

### Action:
Add ["s3:ListBucket","s3:GetObject"], for our user pool policy.