### PR TITLE
Feature/data access analyser event forward

### DIFF
--- a/terraform/stacks/unimelb/data_archive/byob_ica_v2.tf
+++ b/terraform/stacks/unimelb/data_archive/byob_ica_v2.tf
@@ -11,29 +11,9 @@ locals {
   pipeline_data_bucket_name_stg = "pipeline-stg-cache-${data.aws_caller_identity.current.account_id}-${data.aws_region.current.name}"
   # prefix for the BYOB data in ICAv2
   icav2_prefix             = "byob-icav2/"
-  account_id_prod          = "472057503814"
-  account_id_stg           = "455634345446"
-  account_id_dev           = "843407916570"
-  target_event_bus_arn_dev = "arn:aws:events:ap-southeast-2:${local.account_id_dev}:event-bus/default"
+  event_bus_arn_umccr_dev_default = "arn:aws:events:ap-southeast-2:${local.account_id_dev}:event-bus/default"
   # The role that the orcabus file manager uses to ingest events.
   orcabus_file_manager_ingest_role = "orcabus-file-manager-ingest-role"
-}
-
-
-################################################################################
-# Common resources
-
-data "aws_iam_policy_document" "eventbridge_assume_role" {
-  statement {
-    effect = "Allow"
-
-    principals {
-      type        = "Service"
-      identifiers = ["events.amazonaws.com"]
-    }
-
-    actions = ["sts:AssumeRole"]
-  }
 }
 
 
@@ -634,7 +614,7 @@ data "aws_iam_policy_document" "put_events_to_dev_bus" {
   statement {
     effect    = "Allow"
     actions   = ["events:PutEvents"]
-    resources = [local.target_event_bus_arn_dev]
+    resources = [local.event_bus_arn_umccr_dev_default]
   }
 }
 
@@ -670,7 +650,7 @@ resource "aws_cloudwatch_event_rule" "put_events_to_dev_bus" {
 
 resource "aws_cloudwatch_event_target" "put_events_to_dev_bus" {
   target_id = "put_events_to_dev_bus"
-  arn       = local.target_event_bus_arn_dev
+  arn       = local.event_bus_arn_umccr_dev_default
   rule      = aws_cloudwatch_event_rule.put_events_to_dev_bus.name
   role_arn  = aws_iam_role.put_events_to_dev_bus.arn
 }

--- a/terraform/stacks/unimelb/data_archive/byob_ica_v2.tf
+++ b/terraform/stacks/unimelb/data_archive/byob_ica_v2.tf
@@ -10,7 +10,7 @@ locals {
   # The bucket holding all staging data
   pipeline_data_bucket_name_stg = "pipeline-stg-cache-${data.aws_caller_identity.current.account_id}-${data.aws_region.current.name}"
   # prefix for the BYOB data in ICAv2
-  icav2_prefix             = "byob-icav2/"
+  icav2_prefix                    = "byob-icav2/"
   event_bus_arn_umccr_dev_default = "arn:aws:events:ap-southeast-2:${local.account_id_dev}:event-bus/default"
   # The role that the orcabus file manager uses to ingest events.
   orcabus_file_manager_ingest_role = "orcabus-file-manager-ingest-role"

--- a/terraform/stacks/unimelb/data_archive/main.tf
+++ b/terraform/stacks/unimelb/data_archive/main.tf
@@ -23,12 +23,14 @@ data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 
 locals {
-  region                 = "ap-southeast-2"
-  stack_name             = "data_archive"
-  this_account_id        = data.aws_caller_identity.current.account_id
-  mgmt_account_id        = "363226301494"
-  cloudtrail_bucket_name = "cloudtrail-logs-${local.mgmt_account_id}-${local.region}"
-  data_trail_name        = "dataTrail"
+  region          = "ap-southeast-2"
+  stack_name      = "data_archive"
+  this_account_id = data.aws_caller_identity.current.account_id
+  mgmt_account_id = "363226301494"
+  account_id_prod = "472057503814"
+  account_id_stg  = "455634345446"
+  account_id_dev  = "843407916570"
+  account_id_org  = "650704067584"
 
   default_tags = {
     "Stack"       = local.stack_name
@@ -37,23 +39,20 @@ locals {
   }
 }
 
-resource "aws_cloudtrail" "dataTrail" {
-  name                          = local.data_trail_name
-  s3_bucket_name                = local.cloudtrail_bucket_name
+################################################################################
+# Common resources
 
-  event_selector {
-    read_write_type           = "All"
-    include_management_events = true
+data "aws_iam_policy_document" "eventbridge_assume_role" {
+  statement {
+    effect = "Allow"
 
-    data_resource {
-      type   = "AWS::S3::Object"
-      values = ["arn:aws:s3"]
+    principals {
+      type        = "Service"
+      identifiers = ["events.amazonaws.com"]
     }
+
+    actions = ["sts:AssumeRole"]
   }
-  tags = merge(
-    local.default_tags,
-    {
-      "umccr:Name" = local.data_trail_name
-    }
-  )
 }
+
+

--- a/terraform/stacks/unimelb/data_archive/security.tf
+++ b/terraform/stacks/unimelb/data_archive/security.tf
@@ -1,0 +1,31 @@
+locals {
+  cloudtrail_bucket_name          = "cloudtrail-logs-${local.mgmt_account_id}-${local.region}"
+  data_trail_name                 = "dataTrail"
+  event_bus_arn_umccr_org_default = "arn:aws:events:ap-southeast-2:${local.account_id_org}:event-bus/default"
+}
+
+
+################################################################################
+# Security resources
+
+resource "aws_cloudtrail" "dataTrail" {
+  name           = local.data_trail_name
+  s3_bucket_name = local.cloudtrail_bucket_name
+
+  event_selector {
+    read_write_type           = "All"
+    include_management_events = true
+
+    data_resource {
+      type   = "AWS::S3::Object"
+      values = ["arn:aws:s3"]
+    }
+  }
+  tags = merge(
+    local.default_tags,
+    {
+      "umccr:Name" = local.data_trail_name
+    }
+  )
+}
+


### PR DESCRIPTION
An addition to the data account Terraform stack

- refactor out a security template
- add EventBridge rule and related permissions / role to forward IAM AccessAnalyser events to the UMCCR org account default event bus (where they should be picked up by an existing rule and forwarded to our #security Slack channel