### PR TITLE
feat: add object tagging permissions for orcabus file manager

### DIFF
--- a/terraform/stacks/unimelb/data_archive/byob_ica_v2.tf
+++ b/terraform/stacks/unimelb/data_archive/byob_ica_v2.tf
@@ -142,7 +142,14 @@ data "aws_iam_policy_document" "production_data" {
     actions = [
       "s3:ListBucket",
       "s3:GetObject",
-      "s3:GetObjectAttributes"
+      # Note, filemanager is not using GetObjectAttributes yet.
+      "s3:GetObjectAttributes",
+      "s3:GetObjectVersionAttributes",
+      "s3:GetObjectVersion",
+      "s3:GetObjectTagging",
+      "s3:GetObjectVersionTagging",
+      "s3:PutObjectTagging",
+      "s3:PutObjectVersionTagging"
     ]
     resources = [
       aws_s3_bucket.production_data.arn,
@@ -184,9 +191,9 @@ resource "aws_s3_bucket_cors_configuration" "production_data" {
     allowed_headers = ["*"]
     allowed_methods = ["HEAD", "GET", "PUT", "POST", "DELETE"]
     allowed_origins = [
-      "https://ica.illumina.com",       # ILMN UI uploads - https://help.ica.illumina.com/home/h-storage/s-awss3
-      "https://orcaui.umccr.org",       # orcaui - https://github.com/umccr/orca-ui
-      "https://orcaui.prod.umccr.org",  # orcaui - https://github.com/umccr/orca-ui
+      "https://ica.illumina.com",      # ILMN UI uploads - https://help.ica.illumina.com/home/h-storage/s-awss3
+      "https://orcaui.umccr.org",      # orcaui - https://github.com/umccr/orca-ui
+      "https://orcaui.prod.umccr.org", # orcaui - https://github.com/umccr/orca-ui
     ]
     expose_headers  = ["ETag", "x-amz-meta-custom-header"]
     max_age_seconds = 3000
@@ -360,7 +367,14 @@ data "aws_iam_policy_document" "staging_data" {
     actions = [
       "s3:ListBucket",
       "s3:GetObject",
-      "s3:GetObjectAttributes"
+      # Note, filemanager is not using GetObjectAttributes yet.
+      "s3:GetObjectAttributes",
+      "s3:GetObjectVersionAttributes",
+      "s3:GetObjectVersion",
+      "s3:GetObjectTagging",
+      "s3:GetObjectVersionTagging",
+      "s3:PutObjectTagging",
+      "s3:PutObjectVersionTagging"
     ]
     resources = [
       aws_s3_bucket.staging_data.arn,
@@ -562,7 +576,14 @@ data "aws_iam_policy_document" "development_data" {
     actions = [
       "s3:ListBucket",
       "s3:GetObject",
-      "s3:GetObjectAttributes"
+      # Note, filemanager is not using GetObjectAttributes yet.
+      "s3:GetObjectAttributes",
+      "s3:GetObjectVersionAttributes",
+      "s3:GetObjectVersion",
+      "s3:GetObjectTagging",
+      "s3:GetObjectVersionTagging",
+      "s3:PutObjectTagging",
+      "s3:PutObjectVersionTagging"
     ]
     resources = [
       aws_s3_bucket.development_data.arn,


### PR DESCRIPTION
Related to https://github.com/umccr/orcabus/pull/585 and https://github.com/umccr/orcabus/pull/587

### Changes
* Adds `s3:GetObjectTagging` and `s3:PutObjectTagging` so that file manager can access the BYOB tagging: https://github.com/umccr/orcabus/pull/585.
* Adds actions that allow versioned object access: https://github.com/umccr/orcabus/pull/587.

Note that I've also included the `s3:GetObjectAttributes` and `s3:GetObjectVersionAttributes`. The file manager is not using these yet, but I think it will also be a good idea to ingest attributes from the metadata at some point, which will make use of these.

I'm pretty sure this will work (I've run `terraform validate` and `terraform plan`).