### PR TITLE
Feat: Add New Admin Cognito User Group

### DIFF
--- a/terraform/stacks/cognito_aai/app_orcaui.tf
+++ b/terraform/stacks/cognito_aai/app_orcaui.tf
@@ -4,7 +4,7 @@
 #
 
 locals {
-  orcaui_page   = "orcaui"
+  orcaui_page = "orcaui"
 
   orcaui_page_domain = "orcaui.${var.base_domain[terraform.workspace]}"
 
@@ -44,7 +44,16 @@ resource "aws_cognito_user_pool_client" "orcaui_page_app_client" {
   allowed_oauth_flows_user_pool_client = true
   allowed_oauth_scopes                 = ["email", "openid", "profile", "aws.cognito.signin.user.admin"]
 
-  id_token_validity = 24
+
+  refresh_token_validity = 30
+  access_token_validity  = 60
+  id_token_validity      = 1
+
+  token_validity_units {
+    refresh_token = "days"
+    access_token  = "minutes"
+    id_token      = "days"
+  }
 
   # Need to explicitly specify this dependency
   depends_on = [aws_cognito_identity_provider.identity_provider]

--- a/terraform/stacks/cognito_aai/main.tf
+++ b/terraform/stacks/cognito_aai/main.tf
@@ -34,7 +34,7 @@ locals {
 
   iam_role_path = "/${local.stack_name_us}/"
 
-  ssm_param_key_client_prefix = "/${local.stack_name_us}/client"  # pls note this namespace param has few references
+  ssm_param_key_client_prefix = "/${local.stack_name_us}/client" # pls note this namespace param has few references
 }
 
 data "aws_region" "current" {}
@@ -92,6 +92,24 @@ resource "aws_cognito_identity_provider" "identity_provider" {
     email    = "email"
     username = "sub"
   }
+}
+
+################################################################################
+# Cognito User Group
+# Defining group roles within this data-portal cognito user pool
+
+
+# admin: 
+# 
+# The admin role should ideally have full read/write permissions within the data-portal Cognito 
+# user pool. The specific actions it can perform depend on the applications/stacks 
+# using this role as their principal.
+# 
+# Use case: OrcaBus Admins
+resource "aws_cognito_user_group" "main" {
+  name         = "admin"
+  user_pool_id = aws_cognito_user_pool.user_pool.id
+  description  = "Admin group role within the data-portal cognito user pool"
 }
 
 ################################################################################


### PR DESCRIPTION
Create an `admin` group within the Cognito user pool. This allows some Authorisation power based on the user included in this group. The first use case will be in the OrcaBus.