### PR TITLE
Add permissions to delete objects from nextflow stack

### DIFF
--- a/terraform/stacks/unimelb/data_archive/byob_ica_v2.tf
+++ b/terraform/stacks/unimelb/data_archive/byob_ica_v2.tf
@@ -628,17 +628,18 @@ data "aws_iam_policy_document" "development_data" {
       ]
     }
     actions = [
-      "s3:GetObject",
       "s3:ListBucket",
       "s3:ListBucketMultipartUploads",
       "s3:ListMultipartUploadParts",
       "s3:AbortMultipartUpload",
+      "s3:GetObject",
       "s3:GetObjectTagging",
       "s3:GetObjectVersionTagging",
+      "s3:GetObjectAttributes",
       "s3:PutObject",
       "s3:PutObjectTagging",
       "s3:PutObjectVersionTagging",
-      "s3:GetObjectAttributes"
+      "s3:DeleteObject"
     ]
     resources = [
       aws_s3_bucket.development_data.arn,


### PR DESCRIPTION
Cache dir generates a lot of temp files.

Wondering if the failures seen in `s3://pipeline-dev-cache-503977275616-ap-southeast-2/byob-icav2/development/cache/oncoanalyser-wgts-dna/20241024e8deca09/f0/b9e99f8f7ebfb74544d2bd8abd0cc0/.fusion.log` might be related.

According to - we need DeleteObject permissions

https://nextflow.io/docs/latest/fusion.html#fusion-page