### PR TITLE
Add object tagging permissions to ICA IAM user

### DIFF
--- a/terraform/stacks/unimelb/data_archive/byob_ica_v2.tf
+++ b/terraform/stacks/unimelb/data_archive/byob_ica_v2.tf
@@ -770,10 +770,16 @@ data "aws_iam_policy_document" "icav2_pipeline_data_user_policy" {
   statement {
     actions = [
       "s3:PutObject",
+      "s3:PutObjectTagging",
+      "s3:PutObjectVersionTagging",
       "s3:GetObject",
+      "s3:GetObjectTagging",
+      "s3:GetObjectVersionTagging",
       "s3:RestoreObject",
       "s3:DeleteObject",
+      "s3:DeleteObjectTagging",
       "s3:DeleteObjectVersion",
+      "s3:DeleteObjectVersionTagging",
       "s3:GetObjectVersion"
     ]
     resources = [


### PR DESCRIPTION
Since the FileManager attaches object tags it seems the default permissions granted to the ICA admin user for BYOB are not sufficient. 
This will add tagging related permissions to the IAM user attached policy to circumvent possible `AccessDenied` errors when trying to copy tagged objects while not having access to those tags. 