### PR TITLE
Update ica cross account role - add DeleteObject

### DIFF
--- a/terraform/stacks/unimelb/data_archive/byob_ica_v2.tf
+++ b/terraform/stacks/unimelb/data_archive/byob_ica_v2.tf
@@ -773,17 +773,18 @@ data "aws_iam_policy_document" "icav2_pipeline_data_user_policy" {
   statement {
     actions = [
       "s3:PutObject",
-      "s3:PutObjectTagging",
-      "s3:PutObjectVersionTagging",
       "s3:GetObject",
-      "s3:GetObjectTagging",
-      "s3:GetObjectVersionTagging",
       "s3:RestoreObject",
       "s3:DeleteObject",
-      "s3:DeleteObjectTagging",
       "s3:DeleteObjectVersion",
+      "s3:GetObjectVersion",
+      # Add tagging
+      "s3:PutObjectTagging",
+      "s3:PutObjectVersionTagging",
+      "s3:GetObjectTagging",
+      "s3:GetObjectVersionTagging",
+      "s3:DeleteObjectTagging",
       "s3:DeleteObjectVersionTagging",
-      "s3:GetObjectVersion"
     ]
     resources = [
       "arn:aws:s3:::${aws_s3_bucket.development_data.id}/*",

--- a/terraform/stacks/unimelb/data_archive/byob_ica_v2.tf
+++ b/terraform/stacks/unimelb/data_archive/byob_ica_v2.tf
@@ -124,6 +124,7 @@ data "aws_iam_policy_document" "production_data" {
     }
     actions = [
       "s3:PutObject",
+      "s3:DeleteObject",
       "s3:ListMultipartUploadParts",
       "s3:AbortMultipartUpload",
       "s3:GetObject"
@@ -350,6 +351,7 @@ data "aws_iam_policy_document" "staging_data" {
     }
     actions = [
       "s3:PutObject",
+      "s3:DeleteObject",
       "s3:ListMultipartUploadParts",
       "s3:AbortMultipartUpload",
       "s3:GetObject"
@@ -560,6 +562,7 @@ data "aws_iam_policy_document" "development_data" {
     }
     actions = [
       "s3:PutObject",
+      "s3:DeleteObject",
       "s3:ListMultipartUploadParts",
       "s3:AbortMultipartUpload",
       "s3:GetObject"


### PR DESCRIPTION
Fixes https://github.com/umccr/infrastructure/issues/491

Adds `s3:DeleteObject` permissions to the ICA cross account copy/move role.