### PR TITLE
Update dev bucket policy for Access Point support

### DIFF
--- a/terraform/stacks/unimelb/data_archive/byob_ica_v2.tf
+++ b/terraform/stacks/unimelb/data_archive/byob_ica_v2.tf
@@ -598,6 +598,7 @@ data "aws_iam_policy_document" "development_data" {
       "${aws_s3_bucket.development_data.arn}/*",
     ]
   }
+
   statement {
      # See https://help.ica.illumina.com/home/h-storage/s-awss3#enabling-cross-account-access-for-copy-and-move-operations
     sid = "icav2_cross_account_access"
@@ -625,6 +626,7 @@ data "aws_iam_policy_document" "development_data" {
       "${aws_s3_bucket.development_data.arn}/*",
     ]
   }
+
   statement {
     sid = "orcabus_file_manager_ingest_access"
     principals {
@@ -648,6 +650,7 @@ data "aws_iam_policy_document" "development_data" {
       "${aws_s3_bucket.development_data.arn}/*",
     ]
   }
+
   statement {
     sid = "data_portal_access"
     principals {
@@ -672,6 +675,7 @@ data "aws_iam_policy_document" "development_data" {
       "${aws_s3_bucket.development_data.arn}/*",
     ]
   }
+
   statement {
     sid = "nextflow_batch"
     principals {
@@ -702,7 +706,31 @@ data "aws_iam_policy_document" "development_data" {
       "${aws_s3_bucket.development_data.arn}/*",
     ]
   }
+
+  statement {
+    sid = "AccessPointDelegation"
+    principals {
+      type        = "AWS"
+      identifiers = [
+        "*"
+      ]
+    }
+    actions = [
+      "s3:ListBucket*",
+      "s3:GetObject*",
+    ]
+    resources = [
+      aws_s3_bucket.development_data.arn,
+      "${aws_s3_bucket.development_data.arn}/*",
+    ]
+    condition {
+      test     = "ForAnyValue:StringEquals"
+      variable = "s3:DataAccessPointAccount"
+      values   = [local.this_account_id]
+    }
+  }
 }
+
 
 # ------------------------------------------------------------------------------
 # CORS configuration for ILMN BYO buckets


### PR DESCRIPTION
Added statement to resource policy of pipeline-dev-cache bucket to allow read access delegation to Access Points in the same account

Fixes https://github.com/umccr/infrastructure/issues/506 (for the development bucket for now)