### PR TITLE
feat(tf-unimelb): grant data mover role permissions

### DIFF
--- a/terraform/stacks/unimelb/data_archive/analysis_archive.tf
+++ b/terraform/stacks/unimelb/data_archive/analysis_archive.tf
@@ -98,6 +98,26 @@ data "aws_iam_policy_document" "analysis_archive" {
       "${aws_s3_bucket.analysis_archive.arn}/*",
     ]
   }
+
+  # Allow the data mover access to copy to this bucket.
+  statement {
+    sid = "orcabus_data_mover_access"
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${local.account_id_prod}:role/${local.orcabus_data_mover_role}"]
+    }
+    actions = [
+      # List is needed for aws s3 sync
+      "s3:ListBucket",
+      "s3:PutObject",
+      "s3:PutObjectTagging",
+      "s3:PutObjectVersionTagging"
+    ]
+    resources = [
+      aws_s3_bucket.analysis_archive.arn,
+      "${aws_s3_bucket.analysis_archive.arn}/*",
+    ]
+  }
 }
 
 # ------------------------------------------------------------------------------

--- a/terraform/stacks/unimelb/data_archive/byob_ica_v2.tf
+++ b/terraform/stacks/unimelb/data_archive/byob_ica_v2.tf
@@ -22,6 +22,7 @@ locals {
   event_bus_arn_umccr_prod_default = "arn:aws:events:ap-southeast-2:${local.account_id_prod}:event-bus/default"
   # The role that the orcabus file manager uses to ingest events.
   orcabus_file_manager_ingest_role = "orcabus-file-manager-ingest-role"
+  orcabus_data_mover_role = "orcabus-data-mover-role"
 }
 
 
@@ -158,6 +159,27 @@ data "aws_iam_policy_document" "production_data" {
       "s3:GetObjectVersionTagging",
       "s3:PutObjectTagging",
       "s3:PutObjectVersionTagging"
+    ]
+    resources = [
+      aws_s3_bucket.production_data.arn,
+      "${aws_s3_bucket.production_data.arn}/*",
+    ]
+  }
+
+  statement {
+    sid = "orcabus_data_mover_access"
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${local.account_id_prod}:role/${local.orcabus_data_mover_role}"]
+    }
+    actions = [
+      "s3:ListBucket",
+      "s3:GetObject",
+      "s3:GetObjectVersion",
+      "s3:GetObjectTagging",
+      "s3:GetObjectVersionTagging",
+      # Also need delete object for moves
+      "s3:DeleteObject"
     ]
     resources = [
       aws_s3_bucket.production_data.arn,
@@ -423,6 +445,28 @@ data "aws_iam_policy_document" "staging_data" {
       "${aws_s3_bucket.staging_data.arn}/*",
     ]
   }
+
+  statement {
+    sid = "orcabus_data_mover_access"
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${local.account_id_stg}:role/${local.orcabus_data_mover_role}"]
+    }
+    actions = [
+      "s3:ListBucket",
+      "s3:GetObject",
+      "s3:GetObjectVersion",
+      "s3:GetObjectTagging",
+      "s3:GetObjectVersionTagging",
+      # Also need delete object for moves
+      "s3:DeleteObject"
+    ]
+    resources = [
+      aws_s3_bucket.staging_data.arn,
+      "${aws_s3_bucket.staging_data.arn}/*",
+    ]
+  }
+
   statement {
     sid = "nextflow_batch"
     principals {
@@ -648,6 +692,28 @@ data "aws_iam_policy_document" "development_data" {
       "${aws_s3_bucket.development_data.arn}/*",
     ]
   }
+
+  statement {
+    sid = "orcabus_data_mover_access"
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${local.account_id_dev}:role/${local.orcabus_data_mover_role}"]
+    }
+    actions = [
+      "s3:ListBucket",
+      "s3:GetObject",
+      "s3:GetObjectVersion",
+      "s3:GetObjectTagging",
+      "s3:GetObjectVersionTagging",
+      # Also need delete object for moves
+      "s3:DeleteObject"
+    ]
+    resources = [
+      aws_s3_bucket.development_data.arn,
+      "${aws_s3_bucket.development_data.arn}/*",
+    ]
+  }
+
   statement {
     sid = "data_portal_access"
     principals {

--- a/terraform/stacks/unimelb/data_archive/byob_ica_v2.tf
+++ b/terraform/stacks/unimelb/data_archive/byob_ica_v2.tf
@@ -459,7 +459,13 @@ data "aws_iam_policy_document" "staging_data" {
       "s3:GetObjectTagging",
       "s3:GetObjectVersionTagging",
       # Also need delete object for moves
-      "s3:DeleteObject"
+      "s3:DeleteObject",
+      # For dev/staging allow moving to the same bucket for testing.
+      "s3:PutObject",
+      "s3:PutObjectTagging",
+      "s3:PutObjectVersionTagging",
+      # List is needed for aws s3 sync
+      "s3:ListBucket"
     ]
     resources = [
       aws_s3_bucket.staging_data.arn,
@@ -706,7 +712,13 @@ data "aws_iam_policy_document" "development_data" {
       "s3:GetObjectTagging",
       "s3:GetObjectVersionTagging",
       # Also need delete object for moves
-      "s3:DeleteObject"
+      "s3:DeleteObject",
+      # For dev/staging allow moving to the same bucket for testing.
+      "s3:PutObject",
+      "s3:PutObjectTagging",
+      "s3:PutObjectVersionTagging",
+      # List is needed for aws s3 sync
+      "s3:ListBucket"
     ]
     resources = [
       aws_s3_bucket.development_data.arn,

--- a/terraform/stacks/unimelb/data_archive/fastq_archive.tf
+++ b/terraform/stacks/unimelb/data_archive/fastq_archive.tf
@@ -114,6 +114,27 @@ data "aws_iam_policy_document" "fastq_archive" {
       "${aws_s3_bucket.fastq_archive.arn}/*"
     ]
   }
+
+  # Allow the data mover access to copy to this bucket.
+  statement {
+    sid = "orcabus_data_mover_access"
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${local.account_id_prod}:role/${local.orcabus_data_mover_role}"]
+    }
+    actions = [
+      # List is needed for aws s3 sync
+      "s3:ListBucket",
+      "s3:PutObject",
+      "s3:PutObjectTagging",
+      "s3:PutObjectVersionTagging"
+    ]
+    resources = [
+      aws_s3_bucket.fastq_archive.arn,
+      "${aws_s3_bucket.fastq_archive.arn}/*"
+    ]
+  }
+
   # Statement to allow access to any principal from the prod account
   statement {
 	  sid = "umccr_prod_account_access"


### PR DESCRIPTION
Related to https://github.com/umccr/orcabus/pull/726

### Changes
* Adds permissions to read and delete objects from the cache buckets.
* Adds permissions to write objects to the fastq and analysis archive bucket.