### PR TITLE
Portal TF: Scaling back down aurora

### DIFF
--- a/terraform/stacks/umccr_data_portal/rds.tf
+++ b/terraform/stacks/umccr_data_portal/rds.tf
@@ -78,24 +78,24 @@ resource "aws_rds_cluster_instance" "db_instance" {
   tags = merge(local.default_tags)
 }
 
-resource "aws_rds_cluster_instance" "db_instance_ro_replica" {
-  count = var.rds_read_replica[terraform.workspace]
-
-  cluster_identifier = aws_rds_cluster.db.id
-  instance_class     = "db.serverless"
-  engine             = aws_rds_cluster.db.engine
-  engine_version     = aws_rds_cluster.db.engine_version
-
-  db_subnet_group_name = aws_rds_cluster.db.db_subnet_group_name
-  publicly_accessible  = false
-  # monitoring_interval  = var.rds_monitoring_interval[terraform.workspace]
-
-  promotion_tier = 2  # scale independently from master node (writer instance)
-
-  apply_immediately = true
-
-  tags = merge(local.default_tags)
-}
+# resource "aws_rds_cluster_instance" "db_instance_ro_replica" {
+#   count = var.rds_read_replica[terraform.workspace]
+#
+#   cluster_identifier = aws_rds_cluster.db.id
+#   instance_class     = "db.serverless"
+#   engine             = aws_rds_cluster.db.engine
+#   engine_version     = aws_rds_cluster.db.engine_version
+#
+#   db_subnet_group_name = aws_rds_cluster.db.db_subnet_group_name
+#   publicly_accessible  = false
+#   # monitoring_interval  = var.rds_monitoring_interval[terraform.workspace]
+#
+#   promotion_tier = 2  # scale independently from master node (writer instance)
+#
+#   apply_immediately = true
+#
+#   tags = merge(local.default_tags)
+# }
 
 locals {
   # for dev, we don't need reader endpoint. so point it to the same default endpoint

--- a/terraform/stacks/umccr_data_portal/variables.tf
+++ b/terraform/stacks/umccr_data_portal/variables.tf
@@ -95,7 +95,7 @@ variable "rds_min_capacity" {
 
 variable "rds_max_capacity" {
   default = {
-    prod = 64.0
+    prod = 16.0
     dev  = 16.0
     stg  = 16.0
   }


### PR DESCRIPTION
* Major data migration data move have completed. Resume normal ops config.
