### PR TITLE
Remove deprecated portal access

### DIFF
--- a/terraform/stacks/unimelb/data_archive/byob_ica_v2.tf
+++ b/terraform/stacks/unimelb/data_archive/byob_ica_v2.tf
@@ -285,31 +285,6 @@ data "aws_iam_policy_document" "production_data" {
   }
 
   statement {
-    sid = "data_portal_access"
-    principals {
-      type        = "AWS"
-      identifiers = ["arn:aws:iam::${local.account_id_prod}:role/data_portal/data_portal_lambda_apis_role"]
-    }
-    actions = sort([
-      "s3:GetBucketLocation",
-      "s3:GetObject",
-      "s3:ListBucket",
-      "s3:ListBucketMultipartUploads",
-      "s3:ListMultipartUploadParts",
-      "s3:AbortMultipartUpload",
-      "s3:GetObjectTagging",
-      "s3:GetObjectVersionTagging",
-      "s3:PutObjectTagging",
-      "s3:PutObjectVersionTagging",
-      "s3:GetObjectAttributes"
-    ])
-    resources = sort([
-      aws_s3_bucket.production_data.arn,
-      "${aws_s3_bucket.production_data.arn}/*",
-    ])
-  }
-
-  statement {
     sid = "nextflow_batch"
     principals {
       type        = "AWS"
@@ -946,31 +921,6 @@ data "aws_iam_policy_document" "development_data" {
       "s3:PutObjectVersionTagging",
       # List is needed for aws s3 sync
       "s3:ListBucket"
-    ])
-    resources = sort([
-      aws_s3_bucket.development_data.arn,
-      "${aws_s3_bucket.development_data.arn}/*",
-    ])
-  }
-
-  statement {
-    sid = "data_portal_access"
-    principals {
-      type        = "AWS"
-      identifiers = ["arn:aws:iam::${local.account_id_dev}:role/data_portal/data_portal_lambda_apis_role"]
-    }
-    actions = sort([
-      "s3:GetBucketLocation",
-      "s3:GetObject",
-      "s3:ListBucket",
-      "s3:ListBucketMultipartUploads",
-      "s3:ListMultipartUploadParts",
-      "s3:AbortMultipartUpload",
-      "s3:GetObjectTagging",
-      "s3:GetObjectVersionTagging",
-      "s3:PutObjectTagging",
-      "s3:PutObjectVersionTagging",
-      "s3:GetObjectAttributes"
     ])
     resources = sort([
       aws_s3_bucket.development_data.arn,


### PR DESCRIPTION
The legacy portal has been removed. 
The bucket policy has to be updated to no longer refer to the portal role.