### PR TITLE
Add FileManager pre-sign access statement to fastq archive bucket

### DIFF
--- a/terraform/stacks/unimelb/data_archive/fastq_archive.tf
+++ b/terraform/stacks/unimelb/data_archive/fastq_archive.tf
@@ -123,6 +123,22 @@ data "aws_iam_policy_document" "fastq_archive" {
     ])
   }
 
+  statement {
+    sid = "orcabus_file_manager_presign_access"
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${local.account_id_prod}:user/${local.orcabus_file_manager_presign_user}"]
+    }
+    actions = sort([
+      "s3:ListBucket",
+      "s3:GetObject",
+    ])
+    resources = sort([
+      aws_s3_bucket.fastq_archive.arn,
+      "${aws_s3_bucket.fastq_archive.arn}/*",
+    ])
+  }
+
   # Allow the data mover access to copy to this bucket.
   statement {
     sid = "orcabus_data_mover_access"


### PR DESCRIPTION
Add a statement to the fastq archive bucket policy to allow the FileManager pre-sign user access (following the template from the BYOB cache bucket).

This should allow the OrcaUI to serve (unarchived) data from the fastq archive like MultiQC reports.
(See: https://umccr.slack.com/archives/C025TLC7D/p1747108301357219)

FYI @mmalenic 