### PR TITLE
feat: add ListBucketVersions for filemanager presign user

### DIFF
--- a/terraform/stacks/unimelb/data_archive/analysis_archive.tf
+++ b/terraform/stacks/unimelb/data_archive/analysis_archive.tf
@@ -100,6 +100,7 @@ data "aws_iam_policy_document" "analysis_archive" {
     }
     actions = sort([
       "s3:ListBucket",
+      "s3:ListBucketVersions",
       "s3:GetObject",
       # Note, filemanager is not using GetObjectAttributes yet.
       "s3:GetObjectAttributes",

--- a/terraform/stacks/unimelb/data_archive/analysis_archive.tf
+++ b/terraform/stacks/unimelb/data_archive/analysis_archive.tf
@@ -125,6 +125,7 @@ data "aws_iam_policy_document" "analysis_archive" {
     }
     actions = sort([
       "s3:ListBucket",
+      "s3:ListBucketVersions",
       "s3:GetObject"
     ])
     resources = sort([

--- a/terraform/stacks/unimelb/data_archive/byob_ica_v2.tf
+++ b/terraform/stacks/unimelb/data_archive/byob_ica_v2.tf
@@ -231,6 +231,7 @@ data "aws_iam_policy_document" "production_data" {
     }
     actions = sort([
       "s3:ListBucket",
+      "s3:ListBucketVersions",
       "s3:GetObject",
       # Note, filemanager is not using GetObjectAttributes yet.
       "s3:GetObjectAttributes",
@@ -551,6 +552,7 @@ data "aws_iam_policy_document" "staging_data" {
     }
     actions = sort([
       "s3:ListBucket",
+      "s3:ListBucketVersions",
       "s3:GetObject",
       # Note, filemanager is not using GetObjectAttributes yet.
       "s3:GetObjectAttributes",
@@ -871,6 +873,7 @@ data "aws_iam_policy_document" "development_data" {
     }
     actions = sort([
       "s3:ListBucket",
+      "s3:ListBucketVersions",
       "s3:GetObject",
       # Note, filemanager is not using GetObjectAttributes yet.
       "s3:GetObjectAttributes",

--- a/terraform/stacks/unimelb/data_archive/byob_ica_v2.tf
+++ b/terraform/stacks/unimelb/data_archive/byob_ica_v2.tf
@@ -255,6 +255,7 @@ data "aws_iam_policy_document" "production_data" {
     }
     actions = sort([
       "s3:ListBucket",
+      "s3:ListBucketVersions",
       "s3:GetObject",
     ])
     resources = sort([
@@ -574,6 +575,7 @@ data "aws_iam_policy_document" "staging_data" {
     }
     actions = sort([
       "s3:ListBucket",
+      "s3:ListBucketVersions",
       "s3:GetObject",
     ])
     resources = sort([
@@ -893,6 +895,7 @@ data "aws_iam_policy_document" "development_data" {
     }
     actions = sort([
       "s3:ListBucket",
+      "s3:ListBucketVersions",
       "s3:GetObject",
     ])
     resources = sort([

--- a/terraform/stacks/unimelb/data_archive/fastq_archive.tf
+++ b/terraform/stacks/unimelb/data_archive/fastq_archive.tf
@@ -131,6 +131,7 @@ data "aws_iam_policy_document" "fastq_archive" {
     }
     actions = sort([
       "s3:ListBucket",
+      "s3:ListBucketVersions",
       "s3:GetObject",
     ])
     resources = sort([

--- a/terraform/stacks/unimelb/data_archive/fastq_archive.tf
+++ b/terraform/stacks/unimelb/data_archive/fastq_archive.tf
@@ -107,6 +107,7 @@ data "aws_iam_policy_document" "fastq_archive" {
     }
     actions = sort([
       "s3:ListBucket",
+      "s3:ListBucketVersions",
       "s3:GetObject",
       # Note, filemanager is not using GetObjectAttributes yet.
       "s3:GetObjectAttributes",


### PR DESCRIPTION
### Changes
* Adds `s3:ListBucketVersions` so that the filemanager API can perform a `ListObjectVersions` operation.

Related to implementing https://github.com/OrcaBus/service-filemanager/issues/8