### PR TITLE
Add new year 2026

### DIFF
--- a/scripts/umccr_pipeline/UMCCR_Library_Tracking_MetaData.js
+++ b/scripts/umccr_pipeline/UMCCR_Library_Tracking_MetaData.js
@@ -1,7 +1,7 @@
 // Google Sheets JS script to generate internal SubjectID values
 // Should be attached to the UMCCR_Library_Tracking_MetaData Google Spreadsheet
 
-var YEARS = ['2019', '2020', '2021', '2022', '2023', '2018', '2017', '2024', '2025'];  // make sure sheets with new data are listed last!
+var YEARS = ['2019', '2020', '2021', '2022', '2023', '2018', '2017', '2024', '2025', '2026'];  // make sure sheets with new data are listed last!
 var SBJ_ID_PREFIX = "SBJ"; // subject ID prefix (before zero filled running number)
 var SBJ_ID_INT_LEN = 5;    // length of the integer part of subject ID (used for zero filling)
 var SBJ_COL_IDX = 0;


### PR DESCRIPTION
Prepare the Lab Metadata Tracking Sheet for the next year - 2026 - by extending the AppScript code.