### PR TITLE
DataLake TF: Destroyed legacy datalake TF stack

### DIFF
--- a/terraform/stacks/umccr_datalake/README.md
+++ b/terraform/stacks/umccr_datalake/README.md
@@ -1,5 +1,13 @@
 # UMCCR Data Lake Warehouse
 
+> DEPRECATION NOTICE:
+> 
+> This stack (DataLake exploration circa ~ 2022-2024) has been deprecated and destroyed from all environments. All related buckets have been wiped as well.
+> 
+> Superseded by OrcaHouse/OncoHouse data warehouse (circa ~2025) projects that organise in the newer warehouse account.
+>
+> ~victor
+
 ```
 export AWS_PROFILE=prod && terraform workspace select prod
 terraform plan


### PR DESCRIPTION
DEPRECATION NOTICE:

* This stack (DataLake exploration circa ~ 2022-2024) has been deprecated
  and destroyed from all environments. All related buckets have been
  wiped as well.
* Superseded by OrcaHouse/OncoHouse data warehouse (circa ~2025) projects
  that organise in the newer warehouse account.
