### PR TITLE
Networking TF: Implemented configuration options to disable NAT Gateway

### DIFF
--- a/terraform/stacks/networking/README.md
+++ b/terraform/stacks/networking/README.md
@@ -182,16 +182,16 @@ app.synth()
 
 ## Workspaces
 
-Login to AWS.
-```
-aws sso login --profile=dev && export AWS_PROFILE=dev
-```
+- Login to AWS. 
+- Having AWS named profile according to [scripts/all-accounts-aws-config.ini](https://github.com/umccr/infrastructure/blob/c37100b/scripts/all-accounts-aws-config.ini)  
 
 This stack uses terraform workspaces.
 ```
 terraform workspace list
   default
   agha
+  data-control
+  enclave
 * dev
   prod
   stg
@@ -200,7 +200,6 @@ terraform workspace list
 It is typically applied against the AWS `prod` and `dev` accounts and uses Terraform workspaces to distinguish between those accounts.
 
 ```
-terraform workspace select dev
-terraform plan
+export AWS_PROFILE=umccr-dev-admin && terraform workspace select dev && terraform plan
 terraform apply
 ```

--- a/terraform/stacks/networking/main.tf
+++ b/terraform/stacks/networking/main.tf
@@ -20,8 +20,24 @@ provider "aws" {
   region  = "ap-southeast-2"
 }
 
+locals {
+  # This configuration controls whether we want to have a NAT Gateway per workspace / account environment
+  # See epic https://github.com/umccr/infrastructure/issues/539
+  enable_nat_gateway_map = {
+    default      = false
+    dev          = true
+    stg          = true
+    prod         = true
+    data-control = false
+    enclave      = false
+    agha         = false
+  }
+  # Index into the map using the current workspace name
+  enable_nat_gateway_per_ws = lookup(local.enable_nat_gateway_map, terraform.workspace, local.enable_nat_gateway_map["default"])
+}
+
 resource "aws_eip" "main_vpc_nat_gateway" {
-  count = 1
+  count  = local.enable_nat_gateway_per_ws ? 1 : 0
   domain = "vpc"
 
   tags = {
@@ -45,7 +61,7 @@ module "main_vpc" {
   database_subnets = ["10.2.40.0/23", "10.2.42.0/23", "10.2.44.0/23"]
 
   # Single NAT Gateway Scenario
-  enable_nat_gateway     = true
+  enable_nat_gateway     = local.enable_nat_gateway_per_ws
   single_nat_gateway     = true
   one_nat_gateway_per_az = false
 


### PR DESCRIPTION
* Added configuration to conditionally disable NAT Gateway for private subnet.
* Still keeping it activated for the current dev, stg, prod environments.
* Winding it down from other dormant accounts with option to quickly back them
  upon request.
