### PR TITLE
Cognito AAI TF: Implemented configuration options to allow localhost dev

### DIFF
--- a/terraform/stacks/cognito_aai/app_local.tf
+++ b/terraform/stacks/cognito_aai/app_local.tf
@@ -5,12 +5,36 @@
 # Enables local development environments to authenticate via OAuth flow
 
 locals {
-  app_local_namespace              = "localhost"
+  ###
+  # This configuration controls whether we want to allow localhost dev against remote Cognito environment
+  #
+  # NOTE:
+  # In typical development scenario, allowing localhost dev against STG/PROD remote Cognito environment should be
+  # _temporary_ by nature. This would ease with developer needing to _debug_ towards a environment-specific Cognito
+  # setup issue. As such debug session should not be last forever.
+  #
+  # Cognito infra team should provision these resources per developer request basis.
+  # A balancing act (team work) between infra and app teams.
+  #
+  # ~victor
+  ###
+  allow_cognito_app_local_map = {
+    default = false
+    dev     = true
+    stg     = false
+    prod    = false
+  }
+  # Index into the map using the current workspace name
+  allow_cognito_app_local_per_ws = lookup(local.allow_cognito_app_local_map, terraform.workspace, local.allow_cognito_app_local_map["default"])
+
+  app_local_namespace  = "localhost"
   app_local_ssm_prefix = "/cognito/localhost-app"
 }
 
 # Localhost app client for local development
 resource "aws_cognito_user_pool_client" "portal_app_client_local" {
+  count = local.allow_cognito_app_local_per_ws ? 1 : 0
+
   name                         = "${local.app_local_namespace}-cognito-client"
   user_pool_id                 = aws_cognito_user_pool.user_pool.id
   supported_identity_providers = ["Google"]
@@ -35,9 +59,11 @@ resource "aws_cognito_user_pool_client" "portal_app_client_local" {
 # Migrate to new parameters under '/cognito/localhost-app/' prefix.
 
 resource "aws_ssm_parameter" "portal_app_client_id_local" {
+  count = local.allow_cognito_app_local_per_ws ? 1 : 0
+
   name  = "/data_portal/client/cog_app_client_id_local"
   type  = "String"
-  value = aws_cognito_user_pool_client.portal_app_client_local.id
+  value = aws_cognito_user_pool_client.portal_app_client_local[count.index].id
   tags  = merge(
     local.default_tags,
     {
@@ -48,9 +74,11 @@ resource "aws_ssm_parameter" "portal_app_client_id_local" {
 }
 
 resource "aws_ssm_parameter" "portal_oauth_redirect_in_local" {
+  count = local.allow_cognito_app_local_per_ws ? 1 : 0
+
   name  = "/data_portal/client/oauth_redirect_in_local"
   type  = "String"
-  value = sort(aws_cognito_user_pool_client.portal_app_client_local.callback_urls)[0]
+  value = sort(aws_cognito_user_pool_client.portal_app_client_local[count.index].callback_urls)[0]
   tags  = merge(
     local.default_tags,
     {
@@ -61,9 +89,11 @@ resource "aws_ssm_parameter" "portal_oauth_redirect_in_local" {
 }
 
 resource "aws_ssm_parameter" "portal_oauth_redirect_out_local" {
+  count = local.allow_cognito_app_local_per_ws ? 1 : 0
+
   name  = "/data_portal/client/oauth_redirect_out_local"
   type  = "String"
-  value = sort(aws_cognito_user_pool_client.portal_app_client_local.logout_urls)[0]
+  value = sort(aws_cognito_user_pool_client.portal_app_client_local[count.index].logout_urls)[0]
   tags  = merge(
     local.default_tags,
     {
@@ -77,22 +107,28 @@ resource "aws_ssm_parameter" "portal_oauth_redirect_out_local" {
 
 
 resource "aws_ssm_parameter" "localhost_app_client_id" {
+  count = local.allow_cognito_app_local_per_ws ? 1 : 0
+
   name  = "${local.app_local_ssm_prefix}/app-client-id"
   type  = "String"
-  value = aws_cognito_user_pool_client.portal_app_client_local.id
+  value = aws_cognito_user_pool_client.portal_app_client_local[count.index].id
   tags  = merge(local.default_tags)
 }
 
 resource "aws_ssm_parameter" "localhost_oauth_redirect_in" {
+  count = local.allow_cognito_app_local_per_ws ? 1 : 0
+
   name  = "${local.app_local_ssm_prefix}/oauth-redirect-in"
   type  = "String"
-  value = sort(aws_cognito_user_pool_client.portal_app_client_local.callback_urls)[0]
+  value = sort(aws_cognito_user_pool_client.portal_app_client_local[count.index].callback_urls)[0]
   tags  = merge(local.default_tags)
 }
 
 resource "aws_ssm_parameter" "localhost_oauth_redirect_out" {
+  count = local.allow_cognito_app_local_per_ws ? 1 : 0
+
   name  = "${local.app_local_ssm_prefix}/oauth-redirect-out"
   type  = "String"
-  value = sort(aws_cognito_user_pool_client.portal_app_client_local.logout_urls)[0]
+  value = sort(aws_cognito_user_pool_client.portal_app_client_local[count.index].logout_urls)[0]
   tags  = merge(local.default_tags)
 }


### PR DESCRIPTION
* Added the configuration to control whether to allow localhost dev against
  remote Cognito environments. The localhost dev against any other environments
  than DEV; should be on per-request basis due specific-environment setup issue.
